### PR TITLE
Fix some details in CORDEX-related entries

### DIFF
--- a/organisation/clmcom-wegc.json
+++ b/organisation/clmcom-wegc.json
@@ -2,7 +2,7 @@
     "@context": "000_context.jsonld",
     "id": "clmcom-wegc",
     "type": "organisation",
-    "drs_name": "CLMCOM-WEGC",
+    "drs_name": "CLMcom-WEGC",
     "members": [
         "wegc"
     ],

--- a/organisation/ncar.json
+++ b/organisation/ncar.json
@@ -6,5 +6,5 @@
     "members": [
         "ncar"
     ],
-    "description": "NCAR"
+    "description": "NSF National Center for Atmospheric Research"
 }

--- a/organisation/nims-kma.json
+++ b/organisation/nims-kma.json
@@ -7,5 +7,5 @@
         "nims",
         "kma"
     ],
-    "description": "NIMS-KMA"
+    "description": "National Institute of Meteorological Sciences, Korea Meteorological Administration"
 }

--- a/organisation/ru-core.json
+++ b/organisation/ru-core.json
@@ -6,5 +6,5 @@
     "members": [
         "ru-core"
     ],
-    "description": "RU-CORE"
+    "description": "Ramkhamhaeng University Center Of Regional Climate Change and Renewable Energy"
 }

--- a/source/ccam-v2307conv17-sn.json
+++ b/source/ccam-v2307conv17-sn.json
@@ -9,7 +9,7 @@
   "cohort": [
     "Registered"
   ],
-  "organisation_id": [],
+  "organisation_id": ["unsw-ccrc"],
   "label": "CCAM-v2307conv17-SN",
   "label_extended": "Conformal Cubic Atmospheric Model version 2307 configuration 2017, with spectral nudging",
   "license": {},

--- a/source/ccam-v2307conv21-sn.json
+++ b/source/ccam-v2307conv21-sn.json
@@ -9,7 +9,7 @@
   "cohort": [
     "Registered"
   ],
-  "organisation_id": [],
+  "organisation_id": ["unsw-ccrc"],
   "label": "CCAM-v2307conv21-SN",
   "label_extended": "Conformal Cubic Atmospheric Model version 2307 configuration 2021, with spectral nudging",
   "license": {},

--- a/source/ccam-v2507-sn.json
+++ b/source/ccam-v2507-sn.json
@@ -9,7 +9,7 @@
   "cohort": [
     "Registered"
   ],
-  "organisation_id": [],
+  "organisation_id": ["unsw-ccrc"],
   "label": "CCAM-v2507-SN",
   "label_extended": "Conformal Cubic Atmospheric Model version 2507 with spectral nudging",
   "license": {},

--- a/source/era5.json
+++ b/source/era5.json
@@ -7,7 +7,7 @@
         "cordex"
     ],
     "cohort": [],
-    "organisation_id": [],
+    "organisation_id": ["ecmwf"],
     "label": "ERA5",
     "label_extended": "ECMWF Reanalysis v5",
     "license": {},

--- a/source/icon-clm-202407-1-1.json
+++ b/source/icon-clm-202407-1-1.json
@@ -17,7 +17,8 @@
         "clmcom-gerics",
         "clmcom-hereon",
         "clmcom-imwm",
-        "clmcom-kit"
+        "clmcom-kit",
+        "clmcom-wegc"
     ],
     "label": "ICON-CLM-202407-1-1",
     "label_extended": "ICON model in Climate Limited-area Mode (ICON-CLM), Version 202407-1-1",

--- a/source/icon-clm-202410-2-1-x2yn2.json
+++ b/source/icon-clm-202410-2-1-x2yn2.json
@@ -9,7 +9,7 @@
   "cohort": [
     "Registered"
   ],
-  "organisation_id": [],
+  "organisation_id": ["clmcom-dwd", "clmcom-hereon", "clmcom-kit", "clmcom-btu"],
   "label": "ICON-CLM-202410-2-1-x2yn2",
   "label_extended": "ICON model in Climate Limited-area Mode (ICON-CLM), Version 202410-2-1, convection-permitting setup with two-step nesting (x2yn2), intermediate ICON-CLM-202407-1-1 simulation at 12 km spatial grid spacing using convection parameterization",
   "license": {},


### PR DESCRIPTION
Hi!

A minor PR to update metadata on some CORDEX-related entry.

- Add institutions to some CORDEX sources
- Add descriptions to some CORDEX institutions
- Add ECMWF as organisation to ERA5
- Fix drs_name of CLMcom-WEGC (lower case "com")

This is to address some "lower priority" issues noted in WCRP-CORDEX/cordex-cmip6-cv#347.