### PR TITLE
Add missing aerosol variables

### DIFF
--- a/variable/abs1000aer.json
+++ b/variable/abs1000aer.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs1000aer",
+    "type": "variable",
+    "drs_name": "abs1000aer",
+    "description": "Ambient Aerosol Absorption Optical Thickness at 1000 nm",
+    "long_name": "Ambient Aerosol Absorption Optical Thickness at 1000 nm",
+    "standard_name": "atmosphere_absorption_optical_thickness_due_to_ambient_aerosol_particles",
+    "units": "1"
+}

--- a/variable/abs350aer.json
+++ b/variable/abs350aer.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs350aer",
+    "type": "variable",
+    "drs_name": "abs350aer",
+    "description": "Ambient Aerosol Absorption Optical Thickness at 350 nm",
+    "long_name": "Ambient Aerosol Absorption Optical Thickness at 350 nm",
+    "standard_name": "atmosphere_absorption_optical_thickness_due_to_ambient_aerosol_particles",
+    "units": "1"
+}

--- a/variable/abs440aer.json
+++ b/variable/abs440aer.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs440aer",
+    "type": "variable",
+    "drs_name": "abs440aer",
+    "description": "Ambient Aerosol Absorption Optical Thickness at 440 nm",
+    "long_name": "Ambient Aerosol Absorption Optical Thickness at 440 nm",
+    "standard_name": "atmosphere_absorption_optical_thickness_due_to_ambient_aerosol_particles",
+    "units": "1"
+}

--- a/variable/abs870aer.json
+++ b/variable/abs870aer.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs870aer",
+    "type": "variable",
+    "drs_name": "abs870aer",
+    "description": "Ambient Aerosol Absorption Optical Thickness at 870 nm",
+    "long_name": "Ambient Aerosol Absorption Optical Thickness at 870 nm",
+    "standard_name": "atmosphere_absorption_optical_thickness_due_to_ambient_aerosol_particles",
+    "units": "1"
+}

--- a/variable/asy1000aer.json
+++ b/variable/asy1000aer.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "asy1000aer",
+    "type": "variable",
+    "drs_name": "asy1000aer",
+    "description": "Aerosol Asymmetry Parameter at 1000 nm",
+    "long_name": "Aerosol Asymmetry Parameter at 1000 nm",
+    "standard_name": "asymmetry_factor_of_ambient_aerosol_particles",
+    "units": "1"
+}

--- a/variable/asy350aer.json
+++ b/variable/asy350aer.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "asy350aer",
+    "type": "variable",
+    "drs_name": "asy350aer",
+    "description": "Aerosol Asymmetry Parameter at 350 nm",
+    "long_name": "Aerosol Asymmetry Parameter at 350 nm",
+    "standard_name": "asymmetry_factor_of_ambient_aerosol_particles",
+    "units": "1"
+}

--- a/variable/asy440aer.json
+++ b/variable/asy440aer.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "asy440aer",
+    "type": "variable",
+    "drs_name": "asy440aer",
+    "description": "Aerosol Asymmetry Parameter at 440 nm",
+    "long_name": "Aerosol Asymmetry Parameter at 440 nm",
+    "standard_name": "asymmetry_factor_of_ambient_aerosol_particles",
+    "units": "1"
+}

--- a/variable/asy550aer.json
+++ b/variable/asy550aer.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "asy550aer",
+    "type": "variable",
+    "drs_name": "asy550aer",
+    "description": "Aerosol Asymmetry Parameter at 550 nm",
+    "long_name": "Aerosol Asymmetry Parameter at 550 nm",
+    "standard_name": "asymmetry_factor_of_ambient_aerosol_particles",
+    "units": "1"
+}

--- a/variable/asy870aer.json
+++ b/variable/asy870aer.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "asy870aer",
+    "type": "variable",
+    "drs_name": "asy870aer",
+    "description": "Aerosol Asymmetry Parameter at 870 nm",
+    "long_name": "Aerosol Asymmetry Parameter at 870 nm",
+    "standard_name": "asymmetry_factor_of_ambient_aerosol_particles",
+    "units": "1"
+}

--- a/variable/ext550aer.json
+++ b/variable/ext550aer.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "ext550aer",
+    "type": "variable",
+    "drs_name": "ext550aer",
+    "description": "Ambient Aerosol Extinction Coefficient at 550 nm",
+    "long_name": "Ambient Aerosol Extinction Coefficient at 550 nm",
+    "standard_name": "volume_extinction_coefficient_in_air_due_to_ambient_aerosol_particles",
+    "units": "m-1"
+}

--- a/variable/ext550bc.json
+++ b/variable/ext550bc.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "ext550bc",
+    "type": "variable",
+    "drs_name": "ext550bc",
+    "description": "Black Carbon Aerosol Extinction Coefficient at 550 nm",
+    "long_name": "Black Carbon Aerosol Extinction Coefficient at 550 nm",
+    "standard_name": "volume_extinction_coefficient_in_air_due_to_black_carbon_ambient_aerosol_particles",
+    "units": "m-1"
+}

--- a/variable/ext550dust.json
+++ b/variable/ext550dust.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "ext550dust",
+    "type": "variable",
+    "drs_name": "ext550dust",
+    "description": "Dust Aerosol Extinction Coefficient at 550 nm",
+    "long_name": "Dust Aerosol Extinction Coefficient at 550 nm",
+    "standard_name": "volume_extinction_coefficient_in_air_due_to_dust_ambient_aerosol_particles",
+    "units": "m-1"
+}

--- a/variable/ext550nh4.json
+++ b/variable/ext550nh4.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "ext550nh4",
+    "type": "variable",
+    "drs_name": "ext550nh4",
+    "description": "Ammonium Aerosol Extinction Coefficient at 550 nm",
+    "long_name": "Ammonium Aerosol Extinction Coefficient at 550 nm",
+    "standard_name": "volume_extinction_coefficient_in_air_due_to_ammonium_ambient_aerosol_particles",
+    "units": "m-1"
+}

--- a/variable/ext550no3.json
+++ b/variable/ext550no3.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "ext550no3",
+    "type": "variable",
+    "drs_name": "ext550no3",
+    "description": "Nitrate Aerosol Extinction Coefficient at 550 nm",
+    "long_name": "Nitrate Aerosol Extinction Coefficient at 550 nm",
+    "standard_name": "volume_extinction_coefficient_in_air_due_to_nitrate_ambient_aerosol_particles",
+    "units": "m-1"
+}

--- a/variable/ext550oa.json
+++ b/variable/ext550oa.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "ext550oa",
+    "type": "variable",
+    "drs_name": "ext550oa",
+    "description": "Organic Matter Aerosol Extinction Coefficient at 550 nm",
+    "long_name": "Organic Matter Aerosol Extinction Coefficient at 550 nm",
+    "standard_name": "volume_extinction_coefficient_in_air_due_to_particulate_organic_matter_ambient_aerosol_particles",
+    "units": "m-1"
+}

--- a/variable/ext550so4.json
+++ b/variable/ext550so4.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "ext550so4",
+    "type": "variable",
+    "drs_name": "ext550so4",
+    "description": "Sulfate Aerosol Extinction Coefficient at 550 nm",
+    "long_name": "Sulfate Aerosol Extinction Coefficient at 550 nm",
+    "standard_name": "volume_extinction_coefficient_in_air_due_to_sulfate_ambient_aerosol_particles",
+    "units": "m-1"
+}

--- a/variable/ext550ss.json
+++ b/variable/ext550ss.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "ext550ss",
+    "type": "variable",
+    "drs_name": "ext550ss",
+    "description": "Sea-Salt Aerosol Extinction Coefficient at 550 nm",
+    "long_name": "Sea-Salt Aerosol Extinction Coefficient at 550 nm",
+    "standard_name": "volume_extinction_coefficient_in_air_due_to_sea_salt_ambient_aerosol_particles",
+    "units": "m-1"
+}

--- a/variable/od1000aer.json
+++ b/variable/od1000aer.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od1000aer",
+    "type": "variable",
+    "drs_name": "od1000aer",
+    "description": "Ambient Aerosol Optical Thickness at 1000nm",
+    "long_name": "Ambient Aerosol Optical Thickness at 1000nm",
+    "standard_name": "atmosphere_optical_thickness_due_to_ambient_aerosol_particles",
+    "units": "1"
+}

--- a/variable/od350aer.json
+++ b/variable/od350aer.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od350aer",
+    "type": "variable",
+    "drs_name": "od350aer",
+    "description": "Ambient Aerosol Optical Thickness at 350nm",
+    "long_name": "Ambient Aerosol Optical Thickness at 350nm",
+    "standard_name": "atmosphere_optical_thickness_due_to_ambient_aerosol_particles",
+    "units": "1"
+}

--- a/variable/od550nh4.json
+++ b/variable/od550nh4.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od550nh4",
+    "type": "variable",
+    "drs_name": "od550nh4",
+    "description": "Ammonium Aerosol Optical Thickness at 550nm",
+    "long_name": "Ammonium Aerosol Optical Thickness at 550nm",
+    "standard_name": "atmosphere_optical_thickness_due_to_ammonium_ambient_aerosol_particles",
+    "units": "1"
+}

--- a/variable/rldsaf.json
+++ b/variable/rldsaf.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "rldsaf",
+    "type": "variable",
+    "drs_name": "rldsaf",
+    "description": "Surface Downwelling Longwave Radiation in Aerosol-Free Sky",
+    "long_name": "Surface Downwelling Longwave Radiation in Aerosol-Free Sky",
+    "standard_name": "surface_downwelling_longwave_flux_in_air_assuming_clear_sky_and_no_aerosol",
+    "units": "W m-2"
+}

--- a/variable/rldscsaf.json
+++ b/variable/rldscsaf.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "rldscsaf",
+    "type": "variable",
+    "drs_name": "rldscsaf",
+    "description": "Clear-Sky Surface Downwelling Longwave Radiation in Aerosol-Free Sky",
+    "long_name": "Clear-Sky Surface Downwelling Longwave Radiation in Aerosol-Free Sky",
+    "standard_name": "surface_downwelling_longwave_flux_in_air_assuming_clear_sky_and_no_aerosol",
+    "units": "W m-2"
+}

--- a/variable/rlusaf.json
+++ b/variable/rlusaf.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "rlusaf",
+    "type": "variable",
+    "drs_name": "rlusaf",
+    "description": "Surface Upwelling Longwave Radiation in Aerosol-Free Sky",
+    "long_name": "Surface Upwelling Longwave Radiation in Aerosol-Free Sky",
+    "standard_name": "surface_upwelling_longwave_flux_in_air_assuming_clear_sky_and_no_aerosol",
+    "units": "W m-2"
+}

--- a/variable/rsdsaf.json
+++ b/variable/rsdsaf.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "rsdsaf",
+    "type": "variable",
+    "drs_name": "rsdsaf",
+    "description": "Surface Downwelling Shortwave Radiation in Aerosol-Free Sky",
+    "long_name": "Surface Downwelling Shortwave Radiation in Aerosol-Free Sky",
+    "standard_name": "surface_downwelling_shortwave_flux_in_air_assuming_clear_sky_and_no_aerosol",
+    "units": "W m-2"
+}

--- a/variable/rsusaf.json
+++ b/variable/rsusaf.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "rsusaf",
+    "type": "variable",
+    "drs_name": "rsusaf",
+    "description": "Surface Upwelling Shortwave Radiation in Aerosol-Free Sky",
+    "long_name": "Surface Upwelling Shortwave Radiation in Aerosol-Free Sky",
+    "standard_name": "surface_upwelling_shortwave_flux_in_air_assuming_clear_sky_and_no_aerosol",
+    "units": "W m-2"
+}

--- a/variable/scat550aer.json
+++ b/variable/scat550aer.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "scat550aer",
+    "type": "variable",
+    "drs_name": "scat550aer",
+    "description": "Ambient Aerosol Scattering Coefficient at 550 nm",
+    "long_name": "Ambient Aerosol Scattering Coefficient at 550 nm",
+    "standard_name": "volume_scattering_coefficient_in_air_due_to_ambient_aerosol_particles",
+    "units": "m-1"
+}

--- a/variable/scat550bc.json
+++ b/variable/scat550bc.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "scat550bc",
+    "type": "variable",
+    "drs_name": "scat550bc",
+    "description": "Black Carbon Aerosol Scattering Coefficient at 550 nm",
+    "long_name": "Black Carbon Aerosol Scattering Coefficient at 550 nm",
+    "standard_name": "volume_scattering_coefficient_in_air_due_to_black_carbon_ambient_aerosol_particles",
+    "units": "m-1"
+}

--- a/variable/scat550dust.json
+++ b/variable/scat550dust.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "scat550dust",
+    "type": "variable",
+    "drs_name": "scat550dust",
+    "description": "Dust Aerosol Scattering Coefficient at 550 nm",
+    "long_name": "Dust Aerosol Scattering Coefficient at 550 nm",
+    "standard_name": "volume_scattering_coefficient_in_air_due_to_dust_ambient_aerosol_particles",
+    "units": "m-1"
+}

--- a/variable/scat550nh4.json
+++ b/variable/scat550nh4.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "scat550nh4",
+    "type": "variable",
+    "drs_name": "scat550nh4",
+    "description": "Ammonium Aerosol Scattering Coefficient at 550 nm",
+    "long_name": "Ammonium Aerosol Scattering Coefficient at 550 nm",
+    "standard_name": "volume_scattering_coefficient_in_air_due_to_ammonium_ambient_aerosol_particles",
+    "units": "m-1"
+}

--- a/variable/scat550no3.json
+++ b/variable/scat550no3.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "scat550no3",
+    "type": "variable",
+    "drs_name": "scat550no3",
+    "description": "Nitrate Aerosol Scattering Coefficient at 550 nm",
+    "long_name": "Nitrate Aerosol Scattering Coefficient at 550 nm",
+    "standard_name": "volume_scattering_coefficient_in_air_due_to_nitrate_ambient_aerosol_particles",
+    "units": "m-1"
+}

--- a/variable/scat550oa.json
+++ b/variable/scat550oa.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "scat550oa",
+    "type": "variable",
+    "drs_name": "scat550oa",
+    "description": "Organic Matter Aerosol Scattering Coefficient at 550 nm",
+    "long_name": "Organic Matter Aerosol Scattering Coefficient at 550 nm",
+    "standard_name": "volume_scattering_coefficient_in_air_due_to_particulate_organic_matter_ambient_aerosol_particles",
+    "units": "m-1"
+}

--- a/variable/scat550so4.json
+++ b/variable/scat550so4.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "scat550so4",
+    "type": "variable",
+    "drs_name": "scat550so4",
+    "description": "Sulfate Aerosol Scattering Coefficient at 550 nm",
+    "long_name": "Sulfate Aerosol Scattering Coefficient at 550 nm",
+    "standard_name": "volume_scattering_coefficient_in_air_due_to_sulfate_ambient_aerosol_particles",
+    "units": "m-1"
+}

--- a/variable/scat550ss.json
+++ b/variable/scat550ss.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "scat550ss",
+    "type": "variable",
+    "drs_name": "scat550ss",
+    "description": "Sea-Salt Aerosol Scattering Coefficient at 550 nm",
+    "long_name": "Sea-Salt Aerosol Scattering Coefficient at 550 nm",
+    "standard_name": "volume_scattering_coefficient_in_air_due_to_sea_salt_ambient_aerosol_particles",
+    "units": "m-1"
+}

--- a/variable/sconcbc.json
+++ b/variable/sconcbc.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sconcbc",
+    "type": "variable",
+    "drs_name": "sconcbc",
+    "description": "Near-Surface Concentration of Black Carbon Aerosol",
+    "long_name": "Near-Surface Concentration of Black Carbon Aerosol",
+    "standard_name": "mass_concentration_of_black_carbon_dry_aerosol_particles_in_air",
+    "units": "kg m-3"
+}

--- a/variable/sconcnh4.json
+++ b/variable/sconcnh4.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sconcnh4",
+    "type": "variable",
+    "drs_name": "sconcnh4",
+    "description": "Near-Surface Concentration of Ammonium Aerosol",
+    "long_name": "Near-Surface Concentration of Ammonium Aerosol",
+    "standard_name": "mass_concentration_of_ammonium_dry_aerosol_particles_in_air",
+    "units": "kg m-3"
+}

--- a/variable/sconcno3.json
+++ b/variable/sconcno3.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sconcno3",
+    "type": "variable",
+    "drs_name": "sconcno3",
+    "description": "Near-Surface Concentration of Nitrate Aerosol",
+    "long_name": "Near-Surface Concentration of Nitrate Aerosol",
+    "standard_name": "mass_concentration_of_nitrate_dry_aerosol_particles_in_air",
+    "units": "kg m-3"
+}

--- a/variable/sconcoa.json
+++ b/variable/sconcoa.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sconcoa",
+    "type": "variable",
+    "drs_name": "sconcoa",
+    "description": "Near-Surface Concentration of Organic Matter Aerosol",
+    "long_name": "Near-Surface Concentration of Organic Matter Aerosol",
+    "standard_name": "mass_concentration_of_particulate_organic_matter_dry_aerosol_particles_in_air",
+    "units": "kg m-3"
+}

--- a/variable/sconcsoa.json
+++ b/variable/sconcsoa.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sconcsoa",
+    "type": "variable",
+    "drs_name": "sconcsoa",
+    "description": "Near-Surface Concentration of Secondary Organic Aerosol",
+    "long_name": "Near-Surface Concentration of Secondary Organic Aerosol",
+    "standard_name": "mass_concentration_of_secondary_particulate_organic_matter_dry_aerosol_particles_in_air",
+    "units": "kg m-3"
+}

--- a/variable/sedbc.json
+++ b/variable/sedbc.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sedbc",
+    "type": "variable",
+    "drs_name": "sedbc",
+    "description": "Sedimentation Flux of Black Carbon Aerosol",
+    "long_name": "Sedimentation Flux of Black Carbon Aerosol",
+    "standard_name": "tendency_of_atmosphere_mass_content_of_black_carbon_dry_aerosol_particles_due_to_sedimentation",
+    "units": "kg m-2 s-1"
+}

--- a/variable/seddust.json
+++ b/variable/seddust.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "seddust",
+    "type": "variable",
+    "drs_name": "seddust",
+    "description": "Sedimentation Flux of Dust Aerosol",
+    "long_name": "Sedimentation Flux of Dust Aerosol",
+    "standard_name": "tendency_of_atmosphere_mass_content_of_dust_dry_aerosol_particles_due_to_sedimentation",
+    "units": "kg m-2 s-1"
+}

--- a/variable/sednh4.json
+++ b/variable/sednh4.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sednh4",
+    "type": "variable",
+    "drs_name": "sednh4",
+    "description": "Sedimentation Rate of Ammonium",
+    "long_name": "Sedimentation Rate of Ammonium",
+    "standard_name": "minus_tendency_of_atmosphere_mass_content_of_ammonium_dry_aerosol_particles_due_to_dry_deposition",
+    "units": "kg m-2 s-1"
+}

--- a/variable/sedno3.json
+++ b/variable/sedno3.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sedno3",
+    "type": "variable",
+    "drs_name": "sedno3",
+    "description": "Sedimentation Rate of Nitrate",
+    "long_name": "Sedimentation Rate of Nitrate",
+    "standard_name": "tendency_of_atmosphere_mass_content_of_nitrate_dry_aerosol_particles_due_to_dry_deposition",
+    "units": "kg m-2 s-1"
+}

--- a/variable/sedoa.json
+++ b/variable/sedoa.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sedoa",
+    "type": "variable",
+    "drs_name": "sedoa",
+    "description": "Sedimentation Rate of Organic Matter",
+    "long_name": "Sedimentation Rate of Organic Matter",
+    "standard_name": "minus_tendency_of_atmosphere_mass_content_of_particulate_organic_matter_dry_aerosol_particles_due_to_dry_deposition",
+    "units": "kg m-2 s-1"
+}

--- a/variable/sedso4.json
+++ b/variable/sedso4.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sedso4",
+    "type": "variable",
+    "drs_name": "sedso4",
+    "description": "Sedimentation Rate of Sulfate",
+    "long_name": "Sedimentation Rate of Sulfate",
+    "standard_name": "minus_tendency_of_atmosphere_mass_content_of_sulfate_dry_aerosol_particles_due_to_dry_deposition",
+    "units": "kg m-2 s-1"
+}

--- a/variable/sedss.json
+++ b/variable/sedss.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sedss",
+    "type": "variable",
+    "drs_name": "sedss",
+    "description": "Sedimentation Rate of Sea-Salt",
+    "long_name": "Sedimentation Rate of Sea-Salt",
+    "standard_name": "minus_tendency_of_atmosphere_mass_content_of_sea_salt_dry_aerosol_particles_due_to_dry_deposition",
+    "units": "kg m-2 s-1"
+}

--- a/variable/ssa550aer.json
+++ b/variable/ssa550aer.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "ssa550aer",
+    "type": "variable",
+    "drs_name": "ssa550aer",
+    "description": "Aerosol Single Scattering Albedo at 550 nm",
+    "long_name": "Aerosol Single Scattering Albedo at 550 nm",
+    "standard_name": "single_scattering_albedo_in_air_due_to_ambient_aerosol_particles",
+    "units": "1"
+}


### PR DESCRIPTION
This PR adds missing aerosol-related variables to the Universe vocabulary.

Added variables include:
- aerosol optical thickness variables
- aerosol asymmetry parameter variables
- aerosol single scattering albedo
- sedimentation flux variables
- aerosol extinction coefficient variables
- aerosol scattering coefficient variables
- aerosol-free radiation variables
- near-surface aerosol concentration variables

These variables were identified as missing from Universe and are needed for CORDEX-CMIP6 aerosol.