### PR TITLE
Add registrations that went into the constants repository

### DIFF
--- a/institution/dwd.json
+++ b/institution/dwd.json
@@ -7,20 +7,21 @@
         "DWD"
     ],
     "labels": [
-        "German Meteorological Service",
-        "Deutscher Wetterdienst"
+        "Deutscher Wetterdienst",
+        "German Meteorological Service"
     ],
-    "description": "German Meteorological Service",
+    "description": "German Meteorological Service (Deutscher Wetterdienst)",
     "location": [
         {
-            "city": "Offenbach am Main",
+            "city": "Offenbach",
             "country": "Germany",
-            "lat": 50.101799,
-            "lon": 8.746422
+            "lat": 50.10061,
+            "lon": 8.76647
         }
     ],
     "ror": "02nrqs528",
     "urls": [
-        "https://www.dwd.de/"
+        "https://www.dwd.de",
+        "http://en.wikipedia.org/wiki/Deutscher_Wetterdienst"
     ]
 }

--- a/institution/metno.json
+++ b/institution/metno.json
@@ -7,19 +7,22 @@
         "METNo"
     ],
     "labels": [
-        "Norwegian Meteorological Institute (METNo)"
+        "Meteorologisk institutt",
+        "Norwegian Meteorological Institute",
+        "MET Norway"
     ],
-    "description": "Norwegian Meteorological Institute (METNo)",
+    "description": "Norwegian Meteorological Institute",
     "location": [
         {
             "city": "Oslo",
             "country": "Norway",
-            "lat": 59.942691,
-            "lon": 10.720641
+            "lat": 59.91273,
+            "lon": 10.74609
         }
     ],
     "ror": "001n36p86",
     "urls": [
-        "https://www.met.no/"
+        "http://met.no",
+        "https://en.wikipedia.org/wiki/Norwegian_Meteorological_Institute"
     ]
 }

--- a/institution/noaa-gfdl.json
+++ b/institution/noaa-gfdl.json
@@ -1,0 +1,37 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "noaa-gfdl",
+    "type": "institution",
+    "drs_name": "NOAA-GFDL",
+    "acronyms": [
+        "GFDL",
+        "NOAA GFDL"
+    ],
+    "labels": [
+        "Department of Commerce Geophysical Fluid Dynamics Laboratory",
+        "Geophysical Fluid Dynamics Laboratory",
+        "NOAA Geophysical Fluid Dynamics Laboratory",
+        "National Oceanic and Atmospheric Administration Geophysical Fluid Dynamics Laboratory",
+        "Princeton University Geophysical Fluid Dynamics Laboratory",
+        "U.S. Department of Commerce Geophysical Fluid Dynamics Laboratory",
+        "U.S. Geophysical Fluid Dynamics Laboratory",
+        "U.S. National Oceanic and Atmospheric Administration Geophysical Fluid Dynamics Laboratory",
+        "United States Department of Commerce Geophysical Fluid Dynamics Laboratory",
+        "United States Geophysical Fluid Dynamics Laboratory",
+        "United States National Oceanic and Atmospheric Administration Geophysical Fluid Dynamics Laboratory"
+    ],
+    "description": "US National Oceanic and Atmospheric Administration's Geophysical Fluid Dynamics Laboratory.",
+    "location": [
+        {
+            "city": "Princeton",
+            "country": "United States",
+            "lat": 40.34872,
+            "lon": -74.65905
+        }
+    ],
+    "ror": "03vmn1898",
+    "urls": [
+        "https://www.gfdl.noaa.gov",
+        "https://en.wikipedia.org/wiki/Geophysical_Fluid_Dynamics_Laboratory"
+    ]
+}

--- a/institution/sysu.json
+++ b/institution/sysu.json
@@ -1,0 +1,26 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sysu",
+    "type": "institution",
+    "drs_name": "SYSU",
+    "acronyms": [],
+    "labels": [
+        "Sun Yat-sen University",
+        "\u4e2d\u5c71\u5927\u5b66"
+    ],
+    "description": "Sun Yat-sen University, a public university in Guangzhou, China.",
+    "location": [
+        {
+            "city": "Guangzhou",
+            "country": "China",
+            "lat": 23.11667,
+            "lon": 113.25
+        }
+    ],
+    "ror": "0064kty71",
+    "urls": [
+        "https://www.sysu.edu.cn/sysuen/",
+        "https://www.sysu.edu.cn",
+        "http://en.wikipedia.org/wiki/Sun_Yat-sen_University"
+    ]
+}

--- a/organisation/dwd.json
+++ b/organisation/dwd.json
@@ -6,5 +6,5 @@
     "members": [
         "dwd"
     ],
-    "description": "DWD"
+    "description": "German Meteorological Service (Deutscher Wetterdienst)"
 }

--- a/organisation/noaa-gfdl.json
+++ b/organisation/noaa-gfdl.json
@@ -4,8 +4,7 @@
     "type": "organisation",
     "drs_name": "NOAA-GFDL",
     "members": [
-        "noaa",
-        "gfdl"
+        "noaa-gfdl"
     ],
-    "description": "NOAA-GFDL"
+    "description": "US National Oceanic and Atmospheric Administration's Geophysical Fluid Dynamics Laboratory."
 }

--- a/organisation/sysu.json
+++ b/organisation/sysu.json
@@ -1,0 +1,10 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sysu",
+    "type": "organisation",
+    "drs_name": "SYSU",
+    "members": [
+        "sysu"
+    ],
+    "description": "Sun Yat-sen University, a public university in Guangzhou, China."
+}


### PR DESCRIPTION
Adding registrations in manually from the constants repository forms:

1. https://github.com/WCRP-CMIP/WCRP-constants/issues/4
1. https://github.com/WCRP-CMIP/WCRP-constants/issues/8
1. https://github.com/WCRP-CMIP/WCRP-constants/issues/3
1. https://github.com/WCRP-CMIP/WCRP-constants/issues/2 

We can automate this translation in future if that's the route we decide to go down (I've used this process to improve the forms which would be used for this if we move the forms into the CMIP7 CVs repo, so both routes are now better). However, for now, we want this in the CVs asap so I've just done this by hand.