### PR TITLE
variable/*.json: move tile/operation-specific long_names to variants

### DIFF
--- a/variable/cveg.json
+++ b/variable/cveg.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "drs_name": "cVeg",
     "description": "\"Content\" indicates a quantity per unit area. \"Vegetation\" means any plants e.g. trees, shrubs, grass. Plants are autotrophs i.e. \"producers\" of biomass using carbon obtained from carbon dioxide.",
-    "long_name": "Carbon Mass in Vegetation on Grass Tiles",
+    "long_name": "Carbon Mass in Vegetation",
     "standard_name": "vegetation_carbon_content",
     "units": "kg m-2"
 }

--- a/variable/cveggrass.json
+++ b/variable/cveggrass.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Carbon Mass in Vegetation on Grass Tiles",
     "drs_name": "cVegGrass",
-    "long_name": null,
+    "long_name": "Carbon Mass in Vegetation on Grass Tiles",
     "standard_name": "vegetation_carbon_content",
     "units": "kg m-2"
 }

--- a/variable/cvegshrub.json
+++ b/variable/cvegshrub.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Carbon Mass in Vegetation on Shrub Tiles",
     "drs_name": "cVegShrub",
-    "long_name": null,
+    "long_name": "Carbon Mass in Vegetation on Shrub Tiles",
     "standard_name": "vegetation_carbon_content",
     "units": "kg m-2"
 }

--- a/variable/cvegtree.json
+++ b/variable/cvegtree.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Carbon Mass in Vegetation on Tree Tiles",
     "drs_name": "cVegTree",
-    "long_name": null,
+    "long_name": "Carbon Mass in Vegetation on Tree Tiles",
     "standard_name": "vegetation_carbon_content",
     "units": "kg m-2"
 }

--- a/variable/gpp.json
+++ b/variable/gpp.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "drs_name": "gpp",
     "description": "\"Production of carbon\" means the production of biomass expressed as the mass of carbon which it contains. Gross primary production is the rate of synthesis of biomass from inorganic precursors by autotrophs (\"producers\"), for example, photosynthesis in plants or phytoplankton. The producers also respire some of this biomass and the difference is \"net_primary_production\". \"Productivity\" means production per unit area. The phrase \"expressed_as\" is used in the construction A_expressed_as_B, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A.",
-    "long_name": "Carbon Mass Flux out of Atmosphere Due to Gross Primary Production on Land [kgC m-2 s-1]",
+    "long_name": "Gross Primary Production on Land as Carbon Mass Flux",
     "standard_name": "gross_primary_productivity_of_biomass_expressed_as_carbon",
     "units": "kg m-2 s-1"
 }

--- a/variable/gppgrass.json
+++ b/variable/gppgrass.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Gross Primary Production on Grass Tiles as Carbon Mass Flux [kgC m-2 s-1]",
     "drs_name": "gppGrass",
-    "long_name": null,
+    "long_name": "Gross Primary Production on Grass Tiles as Carbon Mass Flux",
     "standard_name": "gross_primary_productivity_of_biomass_expressed_as_carbon",
     "units": "kg m-2 s-1"
 }

--- a/variable/gppshrub.json
+++ b/variable/gppshrub.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Gross Primary Production on Shrub Tiles as Carbon Mass Flux [kgC m-2 s-1]",
     "drs_name": "gppShrub",
-    "long_name": null,
+    "long_name": "Gross Primary Production on Shrub Tiles as Carbon Mass Flux",
     "standard_name": "gross_primary_productivity_of_biomass_expressed_as_carbon",
     "units": "kg m-2 s-1"
 }

--- a/variable/gpptree.json
+++ b/variable/gpptree.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Gross Primary Production on Tree Tiles as Carbon Mass Flux [kgC m-2 s-1]",
     "drs_name": "gppTree",
-    "long_name": null,
+    "long_name": "Gross Primary Production on Tree Tiles as Carbon Mass Flux",
     "standard_name": "gross_primary_productivity_of_biomass_expressed_as_carbon",
     "units": "kg m-2 s-1"
 }

--- a/variable/hfls.json
+++ b/variable/hfls.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "drs_name": "hfls",
     "description": "The surface called \"surface\" means the lower boundary of the atmosphere. \"Upward\" indicates a vector component which is positive when directed upward (negative downward). The surface latent heat flux is the exchange of heat between the surface and the air on account of evaporation (including sublimation). In accordance with common usage in geophysical disciplines, \"flux\" implies per unit area, called \"flux density\" in physics.",
-    "long_name": "Ice Sheet Surface Upward Latent Heat Flux",
+    "long_name": "Surface Upward Latent Heat Flux",
     "standard_name": "surface_upward_latent_heat_flux",
     "units": "W m-2"
 }

--- a/variable/hflsis.json
+++ b/variable/hflsis.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Ice Sheet Surface Upward Latent Heat Flux",
     "drs_name": "hflsIs",
-    "long_name": null,
+    "long_name": "Ice Sheet Surface Upward Latent Heat Flux",
     "standard_name": "surface_upward_latent_heat_flux",
     "units": "W m-2"
 }

--- a/variable/hflso.json
+++ b/variable/hflso.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Surface Downward Latent Heat Flux",
     "drs_name": "hflso",
-    "long_name": null,
+    "long_name": "Surface Downward Latent Heat Flux",
     "standard_name": "surface_downward_latent_heat_flux",
     "units": "W m-2"
 }

--- a/variable/hurs.json
+++ b/variable/hurs.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "drs_name": "hurs",
     "description": "",
-    "long_name": "Daily Minimum Near-Surface Relative Humidity over Crop Tile",
+    "long_name": "Near-Surface Relative Humidity",
     "standard_name": "relative_humidity",
     "units": "1"
 }

--- a/variable/hursmax.json
+++ b/variable/hursmax.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Daily Maximum Near-Surface Relative Humidity",
     "drs_name": "hursmax",
-    "long_name": null,
+    "long_name": "Daily Maximum Near-Surface Relative Humidity",
     "standard_name": "relative_humidity",
     "units": "%"
 }

--- a/variable/hursmin.json
+++ b/variable/hursmin.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Daily Minimum Near-Surface Relative Humidity",
     "drs_name": "hursmin",
-    "long_name": null,
+    "long_name": "Daily Minimum Near-Surface Relative Humidity",
     "standard_name": "relative_humidity",
     "units": "%"
 }

--- a/variable/hursmincrop.json
+++ b/variable/hursmincrop.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Daily Minimum Near-Surface Relative Humidity over Crop Tile",
     "drs_name": "hursminCrop",
-    "long_name": null,
+    "long_name": "Daily Minimum Near-Surface Relative Humidity over Crop Tile",
     "standard_name": "relative_humidity",
     "units": "%"
 }

--- a/variable/mlotst.json
+++ b/variable/mlotst.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "drs_name": "mlotst",
     "description": "The ocean mixed layer is the upper part of the ocean, regarded as being well-mixed. The base of the mixed layer defined by \"temperature\", \"sigma\", \"sigma_theta\", \"sigma_t\" or vertical diffusivity is the level at which the quantity indicated differs from its surface value by a certain amount. A coordinate variable or scalar coordinate variable with standard name sea_water_sigma_t_difference can be used to specify the sigma_t criterion that determines the layer thickness. Sigma-t of sea water is the density of water at atmospheric pressure (i.e. the surface) having the same temperature and salinity, minus 1000 kg m-3. \"Thickness\" means the vertical extent of a layer.",
-    "long_name": "Ocean Mixed Layer Thickness Defined by Sigma T of 0.03 kg m-3",
+    "long_name": "Ocean Mixed Layer Thickness Defined by Sigma T",
     "standard_name": "ocean_mixed_layer_thickness_defined_by_sigma_t",
     "units": "m"
 }

--- a/variable/mlotstmax.json
+++ b/variable/mlotstmax.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Maximum Ocean Mixed Layer Thickness Defined by Sigma T",
     "drs_name": "mlotstmax",
-    "long_name": null,
+    "long_name": "Maximum Ocean Mixed Layer Thickness Defined by Sigma T",
     "standard_name": "ocean_mixed_layer_thickness_defined_by_sigma_t",
     "units": "m"
 }

--- a/variable/mlotstmin.json
+++ b/variable/mlotstmin.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Minimum Ocean Mixed Layer Thickness Defined by Sigma T",
     "drs_name": "mlotstmin",
-    "long_name": null,
+    "long_name": "Minimum Ocean Mixed Layer Thickness Defined by Sigma T",
     "standard_name": "ocean_mixed_layer_thickness_defined_by_sigma_t",
     "units": "m"
 }

--- a/variable/mrro.json
+++ b/variable/mrro.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "drs_name": "mrro",
     "description": "Runoff is the liquid water which drains from land. If not specified, \"runoff\" refers to the sum of surface runoff and subsurface drainage. In accordance with common usage in geophysical disciplines, \"flux\" implies per unit area, called \"flux density\" in physics.",
-    "long_name": "Ice Sheet Total Runoff",
+    "long_name": "Total Runoff",
     "standard_name": "runoff_flux",
     "units": "kg m-2 s-1"
 }

--- a/variable/mrrois.json
+++ b/variable/mrrois.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Ice Sheet Total Runoff",
     "drs_name": "mrroIs",
-    "long_name": null,
+    "long_name": "Ice Sheet Total Runoff",
     "standard_name": "runoff_flux",
     "units": "kg m-2 s-1"
 }

--- a/variable/mrrolut.json
+++ b/variable/mrrolut.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Total Runoff from Land-Use Tile",
     "drs_name": "mrroLut",
-    "long_name": null,
+    "long_name": "Total Runoff from Land-Use Tile",
     "standard_name": "runoff_flux",
     "units": "kg m-2 s-1"
 }

--- a/variable/mrsol.json
+++ b/variable/mrsol.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "drs_name": "mrsol",
     "description": "\"Content\" indicates a quantity per unit area. \"Water\" means water in all phases. \"Layer\" means any layer with upper and lower boundaries that have constant values in some vertical coordinate. There must be a vertical coordinate variable indicating the extent of the layer(s). If the layers are model layers, the vertical coordinate can be \"model_level_number\", but it is recommended to specify a physical coordinate (in a scalar or auxiliary coordinate variable) as well. Quantities defined for a soil layer must have a vertical coordinate variable with boundaries indicating the extent of the layer(s).",
-    "long_name": "Mean soil water content at a depth of 1 m",
+    "long_name": "Total Water Content of Soil Layer",
     "standard_name": "mass_content_of_water_in_soil_layer",
     "units": "kg m-2"
 }

--- a/variable/npp.json
+++ b/variable/npp.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "drs_name": "npp",
     "description": "\"Production of carbon\" means the production of biomass expressed as the mass of carbon which it contains. Net primary production is the excess of gross primary production (rate of synthesis of biomass from inorganic precursors) by autotrophs (\"producers\"), for example, photosynthesis in plants or phytoplankton, over the rate at which the autotrophs themselves respire some of this biomass. \"Productivity\" means production per unit area. The phrase \"expressed_as\" is used in the construction A_expressed_as_B, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A.",
-    "long_name": "Net Primary Production on Grass Tiles as Carbon Mass Flux [kgC m-2 s-1]",
+    "long_name": "Net Primary Production on Land as Carbon Mass Flux",
     "standard_name": "net_primary_productivity_of_biomass_expressed_as_carbon",
     "units": "kg m-2 s-1"
 }

--- a/variable/nppgrass.json
+++ b/variable/nppgrass.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Net Primary Production on Grass Tiles as Carbon Mass Flux [kgC m-2 s-1]",
     "drs_name": "nppGrass",
-    "long_name": null,
+    "long_name": "Net Primary Production on Grass Tiles as Carbon Mass Flux",
     "standard_name": "net_primary_productivity_of_biomass_expressed_as_carbon",
     "units": "kg m-2 s-1"
 }

--- a/variable/nppshrub.json
+++ b/variable/nppshrub.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Net Primary Production on Shrub Tiles as Carbon Mass Flux [kgC m-2 s-1]",
     "drs_name": "nppShrub",
-    "long_name": null,
+    "long_name": "Net Primary Production on Shrub Tiles as Carbon Mass Flux",
     "standard_name": "net_primary_productivity_of_biomass_expressed_as_carbon",
     "units": "kg m-2 s-1"
 }

--- a/variable/npptree.json
+++ b/variable/npptree.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Net Primary Production on Tree Tiles as Carbon Mass Flux [kgC m-2 s-1]",
     "drs_name": "nppTree",
-    "long_name": null,
+    "long_name": "Net Primary Production on Tree Tiles as Carbon Mass Flux",
     "standard_name": "net_primary_productivity_of_biomass_expressed_as_carbon",
     "units": "kg m-2 s-1"
 }

--- a/variable/ra.json
+++ b/variable/ra.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "drs_name": "ra",
     "description": "The surface called \"surface\" means the lower boundary of the atmosphere. \"Upward\" indicates a vector component which is positive when directed upward (negative downward). In accordance with common usage in geophysical disciplines, \"flux\" implies per unit area, called \"flux density\" in physics. The chemical formula for carbon dioxide is CO2. The phrase \"expressed_as\" is used in the construction A_expressed_as_B, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A. The specification of a physical process by the phrase \"due_to_\" process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. Plant respiration is the sum of respiration by parts of plants both above and below the soil. It is assumed that all the respired carbon dioxide is emitted to the atmosphere. The term \"plants\" refers to the kingdom of plants in the modern classification which excludes fungi. Plants are autotrophs i.e. \"producers\" of biomass using carbon obtained from carbon dioxide.",
-    "long_name": "Autotrophic Respiration on Shrub Tiles as Carbon Mass Flux [kgC m-2 s-1]",
+    "long_name": "Autotrophic Respiration on Land as Carbon Mass Flux",
     "standard_name": "surface_upward_mass_flux_of_carbon_dioxide_expressed_as_carbon_due_to_plant_respiration",
     "units": "kg m-2 s-1"
 }

--- a/variable/ragrass.json
+++ b/variable/ragrass.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Autotrophic Respiration on Grass Tiles as Carbon Mass Flux [kgC m-2 s-1]",
     "drs_name": "raGrass",
-    "long_name": null,
+    "long_name": "Autotrophic Respiration on Grass Tiles as Carbon Mass Flux",
     "standard_name": "surface_upward_mass_flux_of_carbon_dioxide_expressed_as_carbon_due_to_plant_respiration",
     "units": "kg m-2 s-1"
 }

--- a/variable/rashrub.json
+++ b/variable/rashrub.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Autotrophic Respiration on Shrub Tiles as Carbon Mass Flux [kgC m-2 s-1]",
     "drs_name": "raShrub",
-    "long_name": null,
+    "long_name": "Autotrophic Respiration on Shrub Tiles as Carbon Mass Flux",
     "standard_name": "surface_upward_mass_flux_of_carbon_dioxide_expressed_as_carbon_due_to_plant_respiration",
     "units": "kg m-2 s-1"
 }

--- a/variable/ratree.json
+++ b/variable/ratree.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Autotrophic Respiration on Tree Tiles as Carbon Mass Flux [kgC m-2 s-1]",
     "drs_name": "raTree",
-    "long_name": null,
+    "long_name": "Autotrophic Respiration on Tree Tiles as Carbon Mass Flux",
     "standard_name": "surface_upward_mass_flux_of_carbon_dioxide_expressed_as_carbon_due_to_plant_respiration",
     "units": "kg m-2 s-1"
 }

--- a/variable/rh.json
+++ b/variable/rh.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "drs_name": "rh",
     "description": "The surface called \"surface\" means the lower boundary of the atmosphere. \"Upward\" indicates a vector component which is positive when directed upward (negative downward). In accordance with common usage in geophysical disciplines, \"flux\" implies per unit area, called \"flux density\" in physics. The chemical formula for carbon dioxide is CO2. The phrase \"expressed_as\" is used in the construction A_expressed_as_B, where B is a chemical constituent of A. It means that the quantity indicated by the standard name is calculated solely with respect to the B contained in A, neglecting all other chemical constituents of A. The specification of a physical process by the phrase \"due_to_\" process means that the quantity named is a single term in a sum of terms which together compose the general quantity named by omitting the phrase. Heterotrophic respiration is respiration by heterotrophs (\"consumers\"), which are organisms (including animals and decomposers) that consume other organisms or dead organic material, rather than synthesising organic material from inorganic precursors using energy from the environment (especially sunlight) as autotrophs (\"producers\") do. Heterotrophic respiration goes on both above and within the soil.",
-    "long_name": "Heterotrophic Respiration on Shrub Tiles as Carbon Mass Flux [kgC m-2 s-1]",
+    "long_name": "Heterotrophic Respiration on Land as Carbon Mass Flux",
     "standard_name": "surface_upward_mass_flux_of_carbon_dioxide_expressed_as_carbon_due_to_heterotrophic_respiration",
     "units": "kg m-2 s-1"
 }

--- a/variable/rhgrass.json
+++ b/variable/rhgrass.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Heterotrophic Respiration on Grass Tiles as Carbon Mass Flux [kgC m-2 s-1]",
     "drs_name": "rhGrass",
-    "long_name": null,
+    "long_name": "Heterotrophic Respiration on Grass Tiles as Carbon Mass Flux",
     "standard_name": "surface_upward_mass_flux_of_carbon_dioxide_expressed_as_carbon_due_to_heterotrophic_respiration",
     "units": "kg m-2 s-1"
 }

--- a/variable/rhshrub.json
+++ b/variable/rhshrub.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Heterotrophic Respiration on Shrub Tiles as Carbon Mass Flux [kgC m-2 s-1]",
     "drs_name": "rhShrub",
-    "long_name": null,
+    "long_name": "Heterotrophic Respiration on Shrub Tiles as Carbon Mass Flux",
     "standard_name": "surface_upward_mass_flux_of_carbon_dioxide_expressed_as_carbon_due_to_heterotrophic_respiration",
     "units": "kg m-2 s-1"
 }

--- a/variable/rhtree.json
+++ b/variable/rhtree.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Heterotrophic Respiration on Tree Tiles as Carbon Mass Flux [kgC m-2 s-1]",
     "drs_name": "rhTree",
-    "long_name": null,
+    "long_name": "Heterotrophic Respiration on Tree Tiles as Carbon Mass Flux",
     "standard_name": "surface_upward_mass_flux_of_carbon_dioxide_expressed_as_carbon_due_to_heterotrophic_respiration",
     "units": "kg m-2 s-1"
 }

--- a/variable/rsds.json
+++ b/variable/rsds.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "drs_name": "rsds",
     "description": "The surface called \"surface\" means the lower boundary of the atmosphere. Downwelling radiation is radiation from above. It does not mean \"net downward\". The sign convention is that \"upwelling\" is positive upwards and \"downwelling\" is positive downwards. The term \"shortwave\" means shortwave radiation. Surface downwelling shortwave is the sum of direct and diffuse solar radiation incident on the surface, and is sometimes called \"global radiation\". When thought of as being incident on a surface, a radiative flux is sometimes called \"irradiance\". In addition, it is identical with the quantity measured by a cosine-collector light-meter and sometimes called \"vector irradiance\". In accordance with common usage in geophysical disciplines, \"flux\" implies per unit area, called \"flux density\" in physics.",
-    "long_name": "Surface Downwelling Shortwave Radiation over Snow",
+    "long_name": "Surface Downwelling Shortwave Radiation",
     "standard_name": "surface_downwelling_shortwave_flux_in_air",
     "units": "W m-2"
 }

--- a/variable/rsdscsaf.json
+++ b/variable/rsdscsaf.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Surface Downwelling Clear-Sky, Aerosol-Free Shortwave Radiation",
     "drs_name": "rsdscsaf",
-    "long_name": null,
+    "long_name": "Surface Downwelling Clear-Sky, Aerosol-Free Shortwave Radiation",
     "standard_name": "surface_downwelling_shortwave_flux_in_air_assuming_clear_sky_and_no_aerosol",
     "units": "W m-2"
 }

--- a/variable/rsdscsafbnd.json
+++ b/variable/rsdscsafbnd.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Surface Downwelling Clear-Sky, Aerosol-Free Shortwave Radiation in Bands",
     "drs_name": "rsdscsafbnd",
-    "long_name": null,
+    "long_name": "Surface Downwelling Clear-Sky, Aerosol-Free Shortwave Radiation in Bands",
     "standard_name": "surface_downwelling_shortwave_flux_in_air_assuming_clear_sky_and_no_aerosol",
     "units": "W m-2"
 }

--- a/variable/rsdscsbnd.json
+++ b/variable/rsdscsbnd.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Surface Downwelling Clear-Sky Shortwave Radiation for Each Band",
     "drs_name": "rsdscsbnd",
-    "long_name": null,
+    "long_name": "Surface Downwelling Clear-Sky Shortwave Radiation for Each Band",
     "standard_name": "surface_downwelling_shortwave_flux_in_air_assuming_clear_sky",
     "units": "W m-2"
 }

--- a/variable/rsdsdir.json
+++ b/variable/rsdsdir.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Surface Direct Downwelling Shortwave Radiation",
     "drs_name": "rsdsdir",
-    "long_name": null,
+    "long_name": "Surface Direct Downwelling Shortwave Radiation",
     "standard_name": "surface_direct_downwelling_shortwave_flux_in_air",
     "units": "W m-2"
 }

--- a/variable/rsdsis.json
+++ b/variable/rsdsis.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Ice Sheet Surface Downwelling Shortwave Radiation",
     "drs_name": "rsdsIs",
-    "long_name": null,
+    "long_name": "Ice Sheet Surface Downwelling Shortwave Radiation",
     "standard_name": "surface_downwelling_shortwave_flux_in_air",
     "units": "W m-2"
 }

--- a/variable/rsus.json
+++ b/variable/rsus.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "drs_name": "rsus",
     "description": "The surface called \"surface\" means the lower boundary of the atmosphere. The term \"shortwave\" means shortwave radiation. Upwelling radiation is radiation from below. It does not mean \"net upward\". The sign convention is that \"upwelling\" is positive upwards and \"downwelling\" is positive downwards. When thought of as being incident on a surface, a radiative flux is sometimes called \"irradiance\". In addition, it is identical with the quantity measured by a cosine-collector light-meter and sometimes called \"vector irradiance\". In accordance with common usage in geophysical disciplines, \"flux\" implies per unit area, called \"flux density\" in physics.",
-    "long_name": "Surface Upwelling Shortwave Radiation over Ocean Not Covered by Sea Ice",
+    "long_name": "Surface Upwelling Shortwave Radiation",
     "standard_name": "surface_upwelling_shortwave_flux_in_air",
     "units": "W m-2"
 }

--- a/variable/rsuscsaf.json
+++ b/variable/rsuscsaf.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Surface Upwelling Clean Clear-Sky Shortwave Radiation",
     "drs_name": "rsuscsaf",
-    "long_name": null,
+    "long_name": "Surface Upwelling Clean Clear-Sky Shortwave Radiation",
     "standard_name": "surface_upwelling_shortwave_flux_in_air_assuming_clear_sky_and_no_aerosol",
     "units": "W m-2"
 }

--- a/variable/rsuscsafbnd.json
+++ b/variable/rsuscsafbnd.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Surface Upwelling Clear-Sky, Aerosol-Free Shortwave Radiation in Bands",
     "drs_name": "rsuscsafbnd",
-    "long_name": null,
+    "long_name": "Surface Upwelling Clear-Sky, Aerosol-Free Shortwave Radiation in Bands",
     "standard_name": "surface_upwelling_shortwave_flux_in_air_assuming_clear_sky_and_no_aerosol",
     "units": "W m-2"
 }

--- a/variable/rsuscsbnd.json
+++ b/variable/rsuscsbnd.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Surface Upwelling Clear-Sky Shortwave Radiation for Each Band",
     "drs_name": "rsuscsbnd",
-    "long_name": null,
+    "long_name": "Surface Upwelling Clear-Sky Shortwave Radiation for Each Band",
     "standard_name": "surface_upwelling_shortwave_flux_in_air_assuming_clear_sky",
     "units": "W m-2"
 }

--- a/variable/rsusis.json
+++ b/variable/rsusis.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Ice Sheet Surface Upwelling Shortwave Radiation",
     "drs_name": "rsusIs",
-    "long_name": null,
+    "long_name": "Ice Sheet Surface Upwelling Shortwave Radiation",
     "standard_name": "surface_upwelling_shortwave_flux_in_air",
     "units": "W m-2"
 }

--- a/variable/rsuslut.json
+++ b/variable/rsuslut.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Surface Upwelling Shortwave on Land-Use Tile",
     "drs_name": "rsusLut",
-    "long_name": null,
+    "long_name": "Surface Upwelling Shortwave on Land-Use Tile",
     "standard_name": "surface_upwelling_shortwave_flux_in_air",
     "units": "W m-2"
 }

--- a/variable/siextent.json
+++ b/variable/siextent.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "drs_name": "siextent",
     "description": "The term sea_ice_extent means the total area of all grid cells in which the sea ice area fraction equals or exceeds a threshold, often chosen to be 15 per cent. The threshold must be specified by supplying a coordinate variable or scalar coordinate variable with the standard name of sea_ice_area_fraction. The horizontal domain over which sea ice extent is calculated is described by the associated coordinate variables and coordinate bounds or by a coordinate variable or scalar coordinate variable with the standard name of \"region\" supplied according to section 6.1.1 of the CF conventions. \"Sea ice\" means all ice floating in the sea which has formed from freezing sea water, rather than by other processes such as calving of land ice to form icebergs.",
-    "long_name": "Sea-Ice Extent North",
+    "long_name": "Sea-Ice Extent",
     "standard_name": "sea_ice_extent",
     "units": "m2"
 }

--- a/variable/siextentn.json
+++ b/variable/siextentn.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Sea-Ice Extent North",
     "drs_name": "siextentn",
-    "long_name": null,
+    "long_name": "Sea-Ice Extent North",
     "standard_name": "sea_ice_extent",
     "units": "1e6 km2"
 }

--- a/variable/siextents.json
+++ b/variable/siextents.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Sea-Ice Extent South",
     "drs_name": "siextents",
-    "long_name": null,
+    "long_name": "Sea-Ice Extent South",
     "standard_name": "sea_ice_extent",
     "units": "1e6 km2"
 }

--- a/variable/sithick.json
+++ b/variable/sithick.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "drs_name": "sithick",
     "description": "\"Thickness\" means the vertical extent of a layer. \"Sea ice\" means all ice floating in the sea which has formed from freezing sea water, rather than by other processes such as calving of land ice to form icebergs.",
-    "long_name": "Ridged Ice Thickness",
+    "long_name": "Sea-Ice Thickness",
     "standard_name": "sea_ice_thickness",
     "units": "m"
 }

--- a/variable/sivol.json
+++ b/variable/sivol.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "drs_name": "sivol",
     "description": "\"X_volume\" means the volume occupied by X within the grid cell. \"Sea ice\" means all ice floating in the sea which has formed from freezing sea water, rather than by other processes such as calving of land ice to form icebergs.",
-    "long_name": "Sea-Ice Volume North",
+    "long_name": "Sea-Ice Volume per Area",
     "standard_name": "sea_ice_volume",
     "units": "m3"
 }

--- a/variable/sivoln.json
+++ b/variable/sivoln.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Sea-Ice Volume North",
     "drs_name": "sivoln",
-    "long_name": null,
+    "long_name": "Sea-Ice Volume North",
     "standard_name": "sea_ice_volume",
     "units": "1e3 km3"
 }

--- a/variable/sivols.json
+++ b/variable/sivols.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Sea-Ice Volume South",
     "drs_name": "sivols",
-    "long_name": null,
+    "long_name": "Sea-Ice Volume South",
     "standard_name": "sea_ice_volume",
     "units": "1e3 km3"
 }

--- a/variable/snd.json
+++ b/variable/snd.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "drs_name": "snd",
     "description": "Surface snow refers to the snow on the solid ground or on surface ice cover, but excludes, for example, falling snowflakes and snow on plants. \"Thickness\" means the vertical extent of a layer. Unless indicated in the cell_methods attribute, a quantity is assumed to apply to the whole area of each horizontal grid box. Previously, the qualifier where_type was used to specify that the quantity applies only to the part of the grid box of the named type. Names containing the where_type qualifier are deprecated and newly created data should use the cell_methods attribute to indicate the horizontal area to which the quantity applies.",
-    "long_name": "Snow Thickness",
+    "long_name": "Snow Depth",
     "standard_name": "surface_snow_thickness",
     "units": "m"
 }

--- a/variable/sndmassdyn.json
+++ b/variable/sndmassdyn.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Snow Mass Rate of Change Through Advection by Sea-Ice Dynamics",
     "drs_name": "sndmassdyn",
-    "long_name": null,
+    "long_name": "Snow Mass Rate of Change Through Advection by Sea-Ice Dynamics",
     "standard_name": "tendency_of_surface_snow_amount_due_to_sea_ice_dynamics",
     "units": "kg m-2 s-1"
 }

--- a/variable/sndmassmelt.json
+++ b/variable/sndmassmelt.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Snow Mass Rate of Change Through Melt",
     "drs_name": "sndmassmelt",
-    "long_name": null,
+    "long_name": "Snow Mass Rate of Change Through Melt",
     "standard_name": "surface_snow_melt_flux",
     "units": "kg m-2 s-1"
 }

--- a/variable/sndmasssi.json
+++ b/variable/sndmasssi.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Snow Mass Rate of Change Through Snow-to-Ice Conversion",
     "drs_name": "sndmasssi",
-    "long_name": null,
+    "long_name": "Snow Mass Rate of Change Through Snow-to-Ice Conversion",
     "standard_name": "tendency_of_surface_snow_amount_due_to_conversion_of_snow_to_sea_ice",
     "units": "kg m-2 s-1"
 }

--- a/variable/sndmasssnf.json
+++ b/variable/sndmasssnf.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Snow Mass Change Through Snow Fall",
     "drs_name": "sndmasssnf",
-    "long_name": null,
+    "long_name": "Snow Mass Change Through Snow Fall",
     "standard_name": "snowfall_flux",
     "units": "kg m-2 s-1"
 }

--- a/variable/sndmasssubl.json
+++ b/variable/sndmasssubl.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Snow Mass Rate of Change Through Evaporation or Sublimation",
     "drs_name": "sndmasssubl",
-    "long_name": null,
+    "long_name": "Snow Mass Rate of Change Through Evaporation or Sublimation",
     "standard_name": "tendency_of_atmosphere_mass_content_of_water_vapor_due_to_sublimation_of_surface_snow_and_ice",
     "units": "kg m-2 s-1"
 }

--- a/variable/sndmasswindrif.json
+++ b/variable/sndmasswindrif.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Snow Mass Rate of Change Through Wind Drift of Snow",
     "drs_name": "sndmasswindrif",
-    "long_name": null,
+    "long_name": "Snow Mass Rate of Change Through Wind Drift of Snow",
     "standard_name": "tendency_of_surface_snow_amount_due_to_drifting_into_sea",
     "units": "kg m-2 s-1"
 }

--- a/variable/tas.json
+++ b/variable/tas.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "drs_name": "tas",
     "description": "Air temperature is the bulk temperature of the air, not the surface (skin) temperature. It is strongly recommended that a variable with this standard name should have a units_metadata attribute, with one of the values \"on-scale\" or \"difference\", whichever is appropriate for the data, because it is essential to know whether the temperature is on-scale (meaning relative to the origin of the scale indicated by the units) or refers to temperature differences (implying that the origin of the temperature scale is irrevelant), in order to convert the units correctly (cf. https://cfconventions.org/cf-conventions/cf-conventions.html#temperature-units).",
-    "long_name": "Daily Minimum Near-Surface Air Temperature",
+    "long_name": "Near-Surface Air Temperature",
     "standard_name": "air_temperature",
     "units": "K"
 }

--- a/variable/tasmax.json
+++ b/variable/tasmax.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Daily Maximum Near-Surface Air Temperature",
     "drs_name": "tasmax",
-    "long_name": null,
+    "long_name": "Daily Maximum Near-Surface Air Temperature",
     "standard_name": "air_temperature",
     "units": "K"
 }

--- a/variable/tasmaxcrop.json
+++ b/variable/tasmaxcrop.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Daily Maximum Near-Surface Air Temperature over Crop Tile",
     "drs_name": "tasmaxCrop",
-    "long_name": null,
+    "long_name": "Daily Maximum Near-Surface Air Temperature over Crop Tile",
     "standard_name": "air_temperature",
     "units": "K"
 }

--- a/variable/tasmin.json
+++ b/variable/tasmin.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Daily Minimum Near-Surface Air Temperature",
     "drs_name": "tasmin",
-    "long_name": null,
+    "long_name": "Daily Minimum Near-Surface Air Temperature",
     "standard_name": "air_temperature",
     "units": "K"
 }

--- a/variable/tasmincrop.json
+++ b/variable/tasmincrop.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Daily Minimum Near-Surface Air Temperature over Crop Tile",
     "drs_name": "tasminCrop",
-    "long_name": null,
+    "long_name": "Daily Minimum Near-Surface Air Temperature over Crop Tile",
     "standard_name": "air_temperature",
     "units": "K"
 }

--- a/variable/wap.json
+++ b/variable/wap.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "drs_name": "wap",
     "description": "\"tendency_of_X\" means derivative of X with respect to time. The Lagrangian tendency of a quantity is its rate of change following the motion of the fluid, also called the \"material derivative\" or \"convective derivative\". The Lagrangian tendency of air pressure, often called \"omega\", plays the role of the upward component of air velocity when air pressure is being used as the vertical coordinate. If the vertical air velocity is upwards, it is negative when expressed as a tendency of air pressure; downwards is positive. Air pressure is the force per unit area which would be exerted when the moving gas molecules of which the air is composed strike a theoretical surface of any orientation.",
-    "long_name": "Pressure Tendency",
+    "long_name": "Omega (=dp/dt)",
     "standard_name": "lagrangian_tendency_of_air_pressure",
     "units": "Pa s-1"
 }

--- a/variable/wap19.json
+++ b/variable/wap19.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Omega (=dp/dt)",
     "drs_name": "wap19",
-    "long_name": null,
+    "long_name": "Omega (=dp/dt)",
     "standard_name": "lagrangian_tendency_of_air_pressure",
     "units": "Pa s-1"
 }

--- a/variable/wap2.json
+++ b/variable/wap2.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Mean-Squared Vertical Velocity (Omega)",
     "drs_name": "wap2",
-    "long_name": null,
+    "long_name": "Mean-Squared Vertical Velocity (Omega)",
     "standard_name": "square_of_lagrangian_tendency_of_air_pressure",
     "units": "Pa2 s-2"
 }

--- a/variable/wap27.json
+++ b/variable/wap27.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Omega (=dp/dt)",
     "drs_name": "wap27",
-    "long_name": null,
+    "long_name": "Omega (=dp/dt)",
     "standard_name": "lagrangian_tendency_of_air_pressure",
     "units": "Pa s-1"
 }

--- a/variable/wap4.json
+++ b/variable/wap4.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Omega (=dp/dt)",
     "drs_name": "wap4",
-    "long_name": null,
+    "long_name": "Omega (=dp/dt)",
     "standard_name": "lagrangian_tendency_of_air_pressure",
     "units": "Pa s-1"
 }

--- a/variable/wap500.json
+++ b/variable/wap500.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Pressure Tendency",
     "drs_name": "wap500",
-    "long_name": null,
+    "long_name": "Pressure Tendency",
     "standard_name": "lagrangian_tendency_of_air_pressure",
     "units": "Pa s-1"
 }

--- a/variable/wap7h.json
+++ b/variable/wap7h.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Omega (=dp/dt)",
     "drs_name": "wap7h",
-    "long_name": null,
+    "long_name": "Omega (=dp/dt)",
     "standard_name": "lagrangian_tendency_of_air_pressure",
     "units": "Pa s-1"
 }

--- a/variable/wap8.json
+++ b/variable/wap8.json
@@ -4,7 +4,7 @@
     "type": "variable",
     "description": "Omega (=dp/dt)",
     "drs_name": "wap8",
-    "long_name": null,
+    "long_name": "Omega (=dp/dt)",
     "standard_name": "lagrangian_tendency_of_air_pressure",
     "units": "Pa s-1"
 }


### PR DESCRIPTION
closes #190.

Several root `variable/*.json` terms carry a `long_name` that's specific to one tile or one daily-extreme operation, even though the term is the generic root. The wcrp_cmip7 ATTR004 check then emits a MEDIUM finding on branded CMIP7 files because the registry returns the root long_name and the file's correct variant-specific long_name doesn't match. Per @taylor13 in #190 these are advisory (long_name is suggested, not required), so this PR is registry cleanup rather than a publication unblock.

Variants (`cveggrass`/`cvegshrub`/`cvegtree`, `hursmin`/`hursmax`/`hursmincrop`, `tasmin`/`tasmax`/`tasmincrop`/`tasmaxcrop`, `gpp/npp/ra/rh × grass/shrub/tree`) all had `long_name: null` and the per-variant text sitting in `description`.

This PR:
- moves the per-variant text from `description` to `long_name` on each affected variant (verbatim, same string, different field).
- replaces the root `long_name` on `cveg`, `hurs`, `tas`, `mrsol`, `gpp`, `npp`, `ra`, `rh` with a generic form that doesn't carry a tile / operation / units token.

30 files touched in round 1, all 1-line edits. Round 2 extends to `rsds`, `mrro`, `hfls`, `mlotst`, `siextent`, `sivol`, `sithick`, `snd`, `wap`, `rsus` plus their variants where `long_name: null` and the description has the canonical text. Each root long_name was verified against the CMIP7 metadata corpus (`Compound Name.<table>.<variable>.long_name`) where it's the most common string across all branded compounds.

Example:

```diff
-# variable/cveg.json (before)
-"long_name": "Carbon Mass in Vegetation on Grass Tiles"
+# variable/cveg.json (after)
+"long_name": "Carbon Mass in Vegetation"
```

```diff
-# variable/cvegshrub.json (before)
-"long_name": null
+# variable/cvegshrub.json (after)
+"long_name": "Carbon Mass in Vegetation on Shrub Tiles"
```

73 files total. Sister fix on the plugin side at cc-plugin-wcrp#47 so the lookup picks the right variant rather than always falling back to the root.