### PR TITLE
region/: add missing extratropical lat-band terms (30n-90n, 60s-90s, 60n-90n)

### DIFF
--- a/region/30n-90n.json
+++ b/region/30n-90n.json
@@ -1,0 +1,9 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "30n-90n",
+  "type": "region",
+  "description": "The geographical region of the Earth’s surface between 30 and 90 degrees north.",
+  "drs_name": "30N-90N",
+  "cf_standard_region": null,
+  "iso_region": null
+}

--- a/region/60n-90n.json
+++ b/region/60n-90n.json
@@ -1,0 +1,9 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "60n-90n",
+  "type": "region",
+  "description": "The geographical region of the Earth’s surface between 60 and 90 degrees north.",
+  "drs_name": "60N-90N",
+  "cf_standard_region": null,
+  "iso_region": null
+}

--- a/region/60s-90s.json
+++ b/region/60s-90s.json
@@ -1,0 +1,9 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "60s-90s",
+  "type": "region",
+  "description": "The geographical region of the Earth’s surface between 60 and 90 degrees south.",
+  "drs_name": "60S-90S",
+  "cf_standard_region": null,
+  "iso_region": null
+}


### PR DESCRIPTION
the region collection currently has `30s-90s` (added last week for emd) but none of the obvious siblings. cmip7 publication of hemispheric-subset fx variables on the southern extratropics already needs `30s-90s`, and the matching northern band plus the polar `60n-90n` / `60s-90s` bands are equally valid drs tokens that fail wcrp_cmip7 file001 today. this adds the three missing entries with the same shape and description style as `30s-90s.json`. no other fields touched.