### PR TITLE
variable/wap500.json: align description with the rest of the wap family?

### DIFF
--- a/variable/wap500.json
+++ b/variable/wap500.json
@@ -2,7 +2,7 @@
     "@context": "000_context.jsonld",
     "id": "wap500",
     "type": "variable",
-    "description": "Pressure Tendency",
+    "description": "Omega (=dp/dt)",
     "drs_name": "wap500",
     "long_name": null,
     "standard_name": "lagrangian_tendency_of_air_pressure",


### PR DESCRIPTION
noticed this while extending #191. every other `wap` variant carries `description: "Omega (=dp/dt)"` (wap19, wap27, wap4, wap7h, wap8), but `wap500.json` carries `description: "Pressure Tendency"`. standard_name is `lagrangian_tendency_of_air_pressure` across the whole family, so semantically they're the same quantity at different pressure levels.

is `wap500.description` deliberately different, or is this a copy-paste from when the term was first created? if it's an oversight i think the family-consistent string is right. if there's a reason wap500 should read differently i can close this no problem.