### PR TITLE
Add EMD model entries to `model`

### DIFF
--- a/model/ec_earth3_esm_1_1.json
+++ b/model/ec_earth3_esm_1_1.json
@@ -1,0 +1,18 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ec_earth3_esm_1_1",
+  "type": "model",
+  "name": "",
+  "family": null,
+  "dynamic_components": [],
+  "prescribed_components": [],
+  "omitted_components": [],
+  "description": "The Earth System Model EC-Earth3-ESM is a post-CMIP6 development of the EC-Earth3 model. It comprises a coupled atmosphere-ocean model (including sea ice), dynamic vegetation, an ice sheet model for Greenland and an Antarctic Ice Meltwater emulator. The model can be run in concentration driven mode or with CO2 emissions, featuring a carbon cycle.  1. The dynamic components are: Atmosphere (IFS) including the soil component (HTESSEL), Ocean (with embedded Sea Ice (LIM3) & Ocean Biogeochemistry (PISCES) components) , Land Surface & Subsurface Dynamic Vegetation (LPJ-GUESS), Land Ice for Greenland (PISM). Further, a simple yet fast atmosphere CO2 box model  (one global grid point) for closing the carbon cycle is used. 2. The Atmospheric Chemistry and Aerosols are prescribed. 3. The Antarctic Ice sheet is not modeled itself,  instead an emulator for simulating the Antarctic meltwater flux (on the ocean grid) is in place.",
+  "calendar": [],
+  "release_year": null,
+  "references": [],
+  "model_components": [],
+  "embedded_components": [],
+  "coupled_components": [],
+  "drs_name": "ec-earth3-esm-1-1"
+}

--- a/model/ec_earth3_esm_1_1.json
+++ b/model/ec_earth3_esm_1_1.json
@@ -14,5 +14,5 @@
   "model_components": [],
   "embedded_components": [],
   "coupled_components": [],
-  "drs_name": "ec-earth3-esm-1-1"
+  "drs_name": "EC-Earth3-ESM-1-1"
 }

--- a/model/mri_esm3_4.json
+++ b/model/mri_esm3_4.json
@@ -14,5 +14,5 @@
   "model_components": [],
   "embedded_components": [],
   "coupled_components": [],
-  "drs_name": "mri-esm3-4"
+  "drs_name": "MRI-ESM3-4"
 }

--- a/model/mri_esm3_4.json
+++ b/model/mri_esm3_4.json
@@ -1,0 +1,18 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "mri_esm3_4",
+  "type": "model",
+  "name": "",
+  "family": null,
+  "dynamic_components": [],
+  "prescribed_components": [],
+  "omitted_components": [],
+  "description": "MRI-ESM3.4 is a fully coupled ESM developed by MRI/JMA. It consists of four major component models coupled through the Scup coupler: an atmospheric general circulation model (MRI-AGCM4.4) with embedded land surface processes (iSiB) and terrestrial biogeochemical processes (MRI-LPJ-LCF1.0), an ocean\u2013sea-ice general circulation model (MRI.COM version 5.4) with embedded ocean biogeochemical processes, an aerosol model (MASINGAR mk-3r2), and an atmospheric chemistry model (MRI-CCM3.2).  Land ice is specified and static.",
+  "calendar": [],
+  "release_year": null,
+  "references": [],
+  "model_components": [],
+  "embedded_components": [],
+  "coupled_components": [],
+  "drs_name": "mri-esm3-4"
+}

--- a/model/ukcm2a_0_hh.json
+++ b/model/ukcm2a_0_hh.json
@@ -1,0 +1,18 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ukcm2a_0_hh",
+  "type": "model",
+  "name": "",
+  "family": null,
+  "dynamic_components": [],
+  "prescribed_components": [],
+  "omitted_components": [],
+  "description": "UKCM2a-0-HH is a very-high resolution counterpart to UKCM2-0-LL using an N640 atmosphere grid (20 km in mid latitudes, 31 km at the equator) and a 1/12 degree (8 km) extended ORCA ocean grid. With the exception of the COMORPH A9 convection scheme this model is otherwise equivalent to UKCM2-0-LL.  UKCM2a-0-HH includes a dynamically evolving MetUM GA9a dynamical atmosphere with the embedded GLOMAP-mode aerosol scheme coupled to the JULES GL9 land surface and the GOSI9 configuration of the NEMO ocean and the embedded SI3 sea-ice model.  Land ice is represented through JULES. The ice surface is taken to be one of the surface tile types, and all surface tiles share the same soil information for temperature and moisture in JULES. The specification of land ice gridboxes is done through the tile fractions information. Atmospheric chemistry. UKCM2a-0-HH has a very simplified treatment of aerosol chemistry using prescribed trace gas oxidants. GHGs/CFCs are prescribed from CMIP7 forcings as annual mean global constant values.  UKCM2a-0-HH does not include an ocean biogeochemistry model.",
+  "calendar": [],
+  "release_year": null,
+  "references": [],
+  "model_components": [],
+  "embedded_components": [],
+  "coupled_components": [],
+  "drs_name": "ukcm2a-0-hh"
+}

--- a/model/ukcm2a_0_hh.json
+++ b/model/ukcm2a_0_hh.json
@@ -14,5 +14,5 @@
   "model_components": [],
   "embedded_components": [],
   "coupled_components": [],
-  "drs_name": "ukcm2a-0-hh"
+  "drs_name": "UKCM2a-0-HH"
 }


### PR DESCRIPTION
Automated synchronisation of Essential-Model-Documentation entries.

This pull request adds the `model` entries derived from the EMD `model` entries on `WCRP-CMIP/Essential-Model-Documentation@src-data`.

Generated by `.github/scripts/sync_emd_entries.py`.