### PR TITLE
Add EMD horizontal grid cell entries to `grid`

### DIFF
--- a/grid/g186.json
+++ b/grid/g186.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g186",
+  "type": "grid",
+  "description": "Horizontal grid cell with a tripolar grid type.",
+  "drs_name": "g186",
+  "region": "global"
+}

--- a/grid/g187.json
+++ b/grid/g187.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g187",
+  "type": "grid",
+  "description": "Horizontal grid cell with a icosahedral geodesic dual grid type and 20 x 20 km resolution.",
+  "drs_name": "g187",
+  "region": "global"
+}

--- a/grid/g188.json
+++ b/grid/g188.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g188",
+  "type": "grid",
+  "description": "Horizontal grid cell with a icosahedral geodesic dual grid type and 80 x 80 km resolution.",
+  "drs_name": "g188",
+  "region": "global"
+}

--- a/grid/g189.json
+++ b/grid/g189.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g189",
+  "type": "grid",
+  "description": "Horizontal grid cell with a regular latitude longitude grid type and 1.25 x 1.25 degree resolution.",
+  "drs_name": "g189",
+  "region": "global"
+}

--- a/grid/g190.json
+++ b/grid/g190.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g190",
+  "type": "grid",
+  "description": "Horizontal grid cell with a regular latitude longitude grid type and 360 x 180 degree resolution.",
+  "drs_name": "g190",
+  "region": "global"
+}

--- a/grid/g191.json
+++ b/grid/g191.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g191",
+  "type": "grid",
+  "description": "Horizontal grid cell with a plane projection grid type and 8 x 8 km resolution.",
+  "drs_name": "g191",
+  "region": "antarctica"
+}

--- a/grid/g192.json
+++ b/grid/g192.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g192",
+  "type": "grid",
+  "description": "Horizontal grid cell with a plane projection grid type and 8 x 8 km resolution.",
+  "drs_name": "g192",
+  "region": "antarctica"
+}

--- a/grid/g193.json
+++ b/grid/g193.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g193",
+  "type": "grid",
+  "description": "Horizontal grid cell with a plane projection grid type and 4 x 4 km resolution.",
+  "drs_name": "g193",
+  "region": "greenland"
+}

--- a/grid/g194.json
+++ b/grid/g194.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g194",
+  "type": "grid",
+  "description": "Horizontal grid cell with a plane projection grid type and 4 x 4 km resolution.",
+  "drs_name": "g194",
+  "region": "greenland"
+}

--- a/grid/g195.json
+++ b/grid/g195.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g195",
+  "type": "grid",
+  "description": "Horizontal grid cell with a displaced pole grid type and 0.5 x 0.25 degree resolution.",
+  "drs_name": "g195",
+  "region": "global"
+}

--- a/grid/g196.json
+++ b/grid/g196.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g196",
+  "type": "grid",
+  "description": "Horizontal grid cell with a cubed sphere grid type and 1 x 1 degree resolution.",
+  "drs_name": "g196",
+  "region": "global"
+}

--- a/grid/g197.json
+++ b/grid/g197.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g197",
+  "type": "grid",
+  "description": "Horizontal grid cell with a cubed sphere grid type and 1 x 1 degree resolution.",
+  "drs_name": "g197",
+  "region": "global"
+}

--- a/grid/g198.json
+++ b/grid/g198.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g198",
+  "type": "grid",
+  "description": "Horizontal grid cell with a regular latitude longitude grid type and 3.75 x 2.5 degree resolution.",
+  "drs_name": "g198",
+  "region": "global"
+}


### PR DESCRIPTION
Automated synchronisation of Essential-Model-Documentation entries.

This pull request adds the `grid` entries derived from the EMD `horizontal_grid_cell` entries on `WCRP-CMIP/Essential-Model-Documentation@src-data`.

Generated by `.github/scripts/sync_emd_entries.py`.