### PR TITLE
Add EMD horizontal grid cell entries to `grid`

### DIFF
--- a/grid/g211.json
+++ b/grid/g211.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g211",
+  "type": "grid",
+  "description": "Horizontal grid cell with a displaced pole grid type and 1.0 x 0.5 degree resolution.",
+  "drs_name": "g211",
+  "region": "global"
+}

--- a/grid/g212.json
+++ b/grid/g212.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g212",
+  "type": "grid",
+  "description": "Horizontal grid cell with a displaced pole grid type and 1.0 x 0.5 degree resolution.",
+  "drs_name": "g212",
+  "region": "global"
+}

--- a/grid/g213.json
+++ b/grid/g213.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g213",
+  "type": "grid",
+  "description": "Horizontal grid cell with a tripolar grid type.",
+  "drs_name": "g213",
+  "region": "global"
+}

--- a/grid/g214.json
+++ b/grid/g214.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g214",
+  "type": "grid",
+  "description": "Horizontal grid cell with a regular latitude longitude grid type and 1.875 x 2.25 degree resolution.",
+  "drs_name": "g214",
+  "region": "global"
+}

--- a/grid/g215.json
+++ b/grid/g215.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g215",
+  "type": "grid",
+  "description": "Horizontal grid cell with a regular latitude longitude grid type and 1.875 x 2.25 degree resolution.",
+  "drs_name": "g215",
+  "region": "global"
+}

--- a/grid/g216.json
+++ b/grid/g216.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g216",
+  "type": "grid",
+  "description": "Horizontal grid cell with a tripolar grid type.",
+  "drs_name": "g216",
+  "region": "global"
+}

--- a/grid/tempgrid-matsbn-1782169407.json
+++ b/grid/tempgrid-matsbn-1782169407.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tempgrid-matsbn-1782169407",
+  "type": "grid",
+  "description": "Horizontal grid cell with a tripolar grid type.",
+  "drs_name": "tempgrid-matsbn-1782169407",
+  "region": "global"
+}

--- a/grid/tempgrid-matsbn-1782169407.json
+++ b/grid/tempgrid-matsbn-1782169407.json
@@ -1,8 +1,0 @@
-{
-  "@context": "000_context.jsonld",
-  "id": "tempgrid-matsbn-1782169407",
-  "type": "grid",
-  "description": "Horizontal grid cell with a tripolar grid type.",
-  "drs_name": "tempgrid-matsbn-1782169407",
-  "region": "global"
-}


### PR DESCRIPTION
Automated synchronisation of Essential-Model-Documentation entries.

This pull request adds the `grid` entries derived from the EMD `horizontal_grid_cell` entries on `WCRP-CMIP/Essential-Model-Documentation@src-data`.

Generated by `.github/scripts/sync_emd_entries.py`.