### PR TITLE
Add EMD horizontal grid cell entries to `grid`

### DIFF
--- a/grid/g217.json
+++ b/grid/g217.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g217",
+  "type": "grid",
+  "description": "Horizontal grid cell with a plane projection grid type and 8 x 8 km resolution.",
+  "drs_name": "g217",
+  "region": "antarctica"
+}

--- a/grid/g218.json
+++ b/grid/g218.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g218",
+  "type": "grid",
+  "description": "Horizontal grid cell with a plane projection grid type and 9.6 x 9.6 km resolution.",
+  "drs_name": "g218",
+  "region": "greenland"
+}

--- a/grid/g219.json
+++ b/grid/g219.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g219",
+  "type": "grid",
+  "description": "Horizontal grid cell with a displaced pole grid type and 1.0 x 0.5 degree resolution.",
+  "drs_name": "g219",
+  "region": "global"
+}

--- a/grid/g220.json
+++ b/grid/g220.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g220",
+  "type": "grid",
+  "description": "Horizontal grid cell with a displaced pole grid type and 0.5 x 0.25 degree resolution.",
+  "drs_name": "g220",
+  "region": "global"
+}

--- a/grid/g221.json
+++ b/grid/g221.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g221",
+  "type": "grid",
+  "description": "Horizontal grid cell with a displaced pole grid type and 0.5 x 0.25 degree resolution.",
+  "drs_name": "g221",
+  "region": "global"
+}

--- a/grid/g222.json
+++ b/grid/g222.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g222",
+  "type": "grid",
+  "description": "Horizontal grid cell with a regular latitude longitude grid type and 2.0 x 1.5 degree resolution.",
+  "drs_name": "g222",
+  "region": "global"
+}

--- a/grid/g223.json
+++ b/grid/g223.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g223",
+  "type": "grid",
+  "description": "Horizontal grid cell with a regular latitude longitude grid type and 2.0 x 1.5 degree resolution.",
+  "drs_name": "g223",
+  "region": "global"
+}

--- a/grid/g224.json
+++ b/grid/g224.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g224",
+  "type": "grid",
+  "description": "Horizontal grid cell with a regular latitude longitude grid type and 1.25 x 1.0 degree resolution.",
+  "drs_name": "g224",
+  "region": "global"
+}

--- a/grid/g225.json
+++ b/grid/g225.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g225",
+  "type": "grid",
+  "description": "Horizontal grid cell with a regular latitude longitude grid type and 1.25 x 1.0 degree resolution.",
+  "drs_name": "g225",
+  "region": "global"
+}

--- a/grid/g226.json
+++ b/grid/g226.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g226",
+  "type": "grid",
+  "description": "Horizontal grid cell with a tripolar grid type and 0.1 x 0.1 degree resolution.",
+  "drs_name": "g226",
+  "region": "global"
+}


### PR DESCRIPTION
Automated synchronisation of Essential-Model-Documentation entries.

This pull request adds the `grid` entries derived from the EMD `horizontal_grid_cell` entries on `WCRP-CMIP/Essential-Model-Documentation@src-data`.

Generated by `.github/scripts/sync_emd_entries.py`.