### PR TITLE
Fix up required components

### DIFF
--- a/experiment/piclim-histaer.json
+++ b/experiment/piclim-histaer.json
@@ -7,14 +7,14 @@
     "start_timestamp": "1850-01-01",
     "activity": "rfmip",
     "additional_allowed_model_components": [
+        "aer",
         "chem",
         "bgc"
     ],
     "branch_information": null,
     "min_ensemble_size": 1,
     "required_model_components": [
-        "aogcm",
-        "aer"
+        "agcm"
     ],
     "tier": 1
 }

--- a/experiment/piclim-histall.json
+++ b/experiment/piclim-histall.json
@@ -7,14 +7,14 @@
     "start_timestamp": "1850-01-01",
     "activity": "rfmip",
     "additional_allowed_model_components": [
+        "aer",
         "chem",
         "bgc"
     ],
     "branch_information": null,
     "min_ensemble_size": 1,
     "required_model_components": [
-        "aogcm",
-        "aer"
+        "agcm"
     ],
     "tier": 1
 }

--- a/scripts/generate-experiments.py
+++ b/scripts/generate-experiments.py
@@ -1159,8 +1159,8 @@ class Holder(BaseModel):
                     "a future experiment",
                     "the `scen7-m` or `esm-scen7-m` experiment (whichever is relevant to your model setup)",
                 ),
-                ["aogcm", "aer"],
-                ["chem", "bgc"],
+                ["agcm"],
+                ["aer", "chem", "bgc"],
             ),
             (
                 "piClim-histall",
@@ -1175,8 +1175,8 @@ class Holder(BaseModel):
                     "a future experiment",
                     "the `scen7-m` or `esm-scen7-m` experiment (whichever is relevant to your model setup)",
                 ),
-                ["aogcm", "aer"],
-                ["chem", "bgc"],
+                ["agcm"],
+                ["aer", "chem", "bgc"],
             ),
         ):
             univ = ExperimentUniverse(


### PR DESCRIPTION
@rigoudyg could you please double check this. In particular, is interactive aerosol chemistry `aer` required for `piClim-histaer` or is it optional (I guess you could diagnose aerosol ERF using simple plumes)?

Closes #248 