### PR TITLE
feat: add missing cmip6plus universe terms

### DIFF
--- a/experiment/tipmip-ocn-p1t1-aa.json
+++ b/experiment/tipmip-ocn-p1t1-aa.json
@@ -1,0 +1,34 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tipmip-ocn-p1t1-aa",
+  "type": "experiment",
+  "experiment_id": "tipmip-ocn-p1t1-aa",
+  "activity_id": [
+    "tipmip"
+  ],
+  "additional_allowed_model_components": [
+    "aer",
+    "bgc",
+    "chem",
+    "ism"
+  ],
+  "description": "Ramp-up run with increasing CO2 emissions leading to a warming of ~2K/century with increasing freshwater release from 0 to 0.3 Sv in ~100 yrs.",
+  "end_year": null,
+  "experiment": "Ramp-up around Greenland",
+  "min_number_yrs_per_sim": 100,
+  "parent_activity_id": [
+    "tipmip"
+  ],
+  "parent_experiment_id": [
+    "esm-picontrol"
+  ],
+  "required_model_components": [
+    "aogcm"
+  ],
+  "start_year": null,
+  "sub_experiment_id": [
+    "none"
+  ],
+  "tier": 1,
+  "drs_name": "tipmip-ocn-p1t1-Aa"
+}

--- a/experiment/tipmip-ocn-p1t1-ab.json
+++ b/experiment/tipmip-ocn-p1t1-ab.json
@@ -1,0 +1,34 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tipmip-ocn-p1t1-ab",
+  "type": "experiment",
+  "experiment_id": "tipmip-ocn-p1t1-ab",
+  "activity_id": [
+    "tipmip"
+  ],
+  "additional_allowed_model_components": [
+    "aer",
+    "bgc",
+    "chem",
+    "ism"
+  ],
+  "description": "Zero emission run starting directly after Aa with freshwater release kept at 0.3 Sv.",
+  "end_year": null,
+  "experiment": "Constant around Greenland",
+  "min_number_yrs_per_sim": 250,
+  "parent_activity_id": [
+    "tipmip"
+  ],
+  "parent_experiment_id": [
+    "tipmip-ocn-p1t1-aa"
+  ],
+  "required_model_components": [
+    "aogcm"
+  ],
+  "start_year": null,
+  "sub_experiment_id": [
+    "none"
+  ],
+  "tier": 1,
+  "drs_name": "tipmip-ocn-p1t1-Ab"
+}

--- a/experiment/tipmip-ocn-p1t1-ac.json
+++ b/experiment/tipmip-ocn-p1t1-ac.json
@@ -1,0 +1,34 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tipmip-ocn-p1t1-ac",
+  "type": "experiment",
+  "experiment_id": "tipmip-ocn-p1t1-ac",
+  "activity_id": [
+    "tipmip"
+  ],
+  "additional_allowed_model_components": [
+    "aer",
+    "bgc",
+    "chem",
+    "ism"
+  ],
+  "description": "Ramp-down with decreasing CO2 emissions leading to a cooling of ~2K/century with decreasing freshwater release from 0.3 to 0 Sv over ~100 years.",
+  "end_year": null,
+  "experiment": "Ramp-down around Greenland",
+  "min_number_yrs_per_sim": 100,
+  "parent_activity_id": [
+    "tipmip"
+  ],
+  "parent_experiment_id": [
+    "tipmip-ocn-p1t1-ab"
+  ],
+  "required_model_components": [
+    "aogcm"
+  ],
+  "start_year": null,
+  "sub_experiment_id": [
+    "none"
+  ],
+  "tier": 1,
+  "drs_name": "tipmip-ocn-p1t1-Ac"
+}

--- a/experiment/tipmip-ocn-p1t1-ad.json
+++ b/experiment/tipmip-ocn-p1t1-ad.json
@@ -1,0 +1,34 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tipmip-ocn-p1t1-ad",
+  "type": "experiment",
+  "experiment_id": "tipmip-ocn-p1t1-ad",
+  "activity_id": [
+    "tipmip"
+  ],
+  "additional_allowed_model_components": [
+    "aer",
+    "bgc",
+    "chem",
+    "ism"
+  ],
+  "description": "Zero emission run starting directly after Ac, with no freshwater release.",
+  "end_year": null,
+  "experiment": "No freshwater release",
+  "min_number_yrs_per_sim": 100,
+  "parent_activity_id": [
+    "tipmip"
+  ],
+  "parent_experiment_id": [
+    "tipmip-ocn-p1t1-ac"
+  ],
+  "required_model_components": [
+    "aogcm"
+  ],
+  "start_year": null,
+  "sub_experiment_id": [
+    "none"
+  ],
+  "tier": 1,
+  "drs_name": "tipmip-ocn-p1t1-Ad"
+}

--- a/experiment/tipmip-ocn-p1t1-ba.json
+++ b/experiment/tipmip-ocn-p1t1-ba.json
@@ -1,0 +1,34 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tipmip-ocn-p1t1-ba",
+  "type": "experiment",
+  "experiment_id": "tipmip-ocn-p1t1-ba",
+  "activity_id": [
+    "tipmip"
+  ],
+  "additional_allowed_model_components": [
+    "aer",
+    "bgc",
+    "chem",
+    "ism"
+  ],
+  "description": "Historical esm-hist simulation starting on 1920 with additional Greenland Ice Sheet melting around Greenland.",
+  "end_year": null,
+  "experiment": "Historical with hosing around Greenland.",
+  "min_number_yrs_per_sim": 94,
+  "parent_activity_id": [
+    "tipmip"
+  ],
+  "parent_experiment_id": [
+    "esm-hist"
+  ],
+  "required_model_components": [
+    "aogcm"
+  ],
+  "start_year": null,
+  "sub_experiment_id": [
+    "none"
+  ],
+  "tier": 1,
+  "drs_name": "tipmip-ocn-p1t1-Ba"
+}

--- a/experiment/tipmip-ocn-p1t1-bb.json
+++ b/experiment/tipmip-ocn-p1t1-bb.json
@@ -1,0 +1,34 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tipmip-ocn-p1t1-bb",
+  "type": "experiment",
+  "experiment_id": "tipmip-ocn-p1t1-bb",
+  "activity_id": [
+    "tipmip"
+  ],
+  "additional_allowed_model_components": [
+    "aer",
+    "bgc",
+    "chem",
+    "ism"
+  ],
+  "description": "ScenarioMIP like SSP2-4.5 simulation starting on 2015 with additional Greenland Ice Sheet melting around Greenland.",
+  "end_year": null,
+  "experiment": "ScenarioMIP SSP2-4.5 with hosing around Greenland.",
+  "min_number_yrs_per_sim": 85,
+  "parent_activity_id": [
+    "tipmip"
+  ],
+  "parent_experiment_id": [
+    "tipmip-ocn-p1t1-ba"
+  ],
+  "required_model_components": [
+    "aogcm"
+  ],
+  "start_year": null,
+  "sub_experiment_id": [
+    "none"
+  ],
+  "tier": 1,
+  "drs_name": "tipmip-ocn-p1t1-Bb"
+}

--- a/experiment/tipmip-ocn-p1t1-ca.json
+++ b/experiment/tipmip-ocn-p1t1-ca.json
@@ -1,0 +1,34 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tipmip-ocn-p1t1-ca",
+  "type": "experiment",
+  "experiment_id": "tipmip-ocn-p1t1-ca",
+  "activity_id": [
+    "tipmip"
+  ],
+  "additional_allowed_model_components": [
+    "aer",
+    "bgc",
+    "chem",
+    "ism"
+  ],
+  "description": "Uniform hosing of 0.3 Sv north of 50 N in North Atlantic to Bering Strait.",
+  "end_year": null,
+  "experiment": "NaHosMIP u03-hos",
+  "min_number_yrs_per_sim": 50,
+  "parent_activity_id": [
+    "tipmip"
+  ],
+  "parent_experiment_id": [
+    "esm-picontrol"
+  ],
+  "required_model_components": [
+    "aogcm"
+  ],
+  "start_year": null,
+  "sub_experiment_id": [
+    "none"
+  ],
+  "tier": 1,
+  "drs_name": "tipmip-ocn-p1t1-Ca"
+}

--- a/experiment/tipmip-ocn-p1t1-cb.json
+++ b/experiment/tipmip-ocn-p1t1-cb.json
@@ -1,0 +1,34 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tipmip-ocn-p1t1-cb",
+  "type": "experiment",
+  "experiment_id": "tipmip-ocn-p1t1-cb",
+  "activity_id": [
+    "tipmip"
+  ],
+  "additional_allowed_model_components": [
+    "aer",
+    "bgc",
+    "chem",
+    "ism"
+  ],
+  "description": "Equivalent to NaHosMIP u03-r50 experiments (Jackson et al. 2023).",
+  "end_year": null,
+  "experiment": "No hosing, initialized from tipmip-ocn-p1t1-Ca.",
+  "min_number_yrs_per_sim": 100,
+  "parent_activity_id": [
+    "tipmip"
+  ],
+  "parent_experiment_id": [
+    "tipmip-ocn-p1t1-ca"
+  ],
+  "required_model_components": [
+    "aogcm"
+  ],
+  "start_year": null,
+  "sub_experiment_id": [
+    "none"
+  ],
+  "tier": 1,
+  "drs_name": "tipmip-ocn-p1t1-Cb"
+}

--- a/experiment/tipmip-ocn-p1t1-da.json
+++ b/experiment/tipmip-ocn-p1t1-da.json
@@ -1,0 +1,34 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tipmip-ocn-p1t1-da",
+  "type": "experiment",
+  "experiment_id": "tipmip-ocn-p1t1-da",
+  "activity_id": [
+    "tipmip"
+  ],
+  "additional_allowed_model_components": [
+    "aer",
+    "bgc",
+    "chem",
+    "ism"
+  ],
+  "description": "Ramp-up to 0.3 Sv in 50 years corresponding to the same amount of freshwater as 50 years of NaHosMIP u03hos.",
+  "end_year": null,
+  "experiment": "Uniform hosing in the Labrador Sea.",
+  "min_number_yrs_per_sim": 50,
+  "parent_activity_id": [
+    "tipmip"
+  ],
+  "parent_experiment_id": [
+    "esm-picontrol"
+  ],
+  "required_model_components": [
+    "aogcm"
+  ],
+  "start_year": null,
+  "sub_experiment_id": [
+    "none"
+  ],
+  "tier": 1,
+  "drs_name": "tipmip-ocn-p1t1-Da"
+}

--- a/experiment/tipmip-ocn-p1t1-db.json
+++ b/experiment/tipmip-ocn-p1t1-db.json
@@ -1,0 +1,34 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tipmip-ocn-p1t1-db",
+  "type": "experiment",
+  "experiment_id": "tipmip-ocn-p1t1-db",
+  "activity_id": [
+    "tipmip"
+  ],
+  "additional_allowed_model_components": [
+    "aer",
+    "bgc",
+    "chem",
+    "ism"
+  ],
+  "description": "Ramp-down from 0.3 Sv to 0.0 Sv in 50 years starting from Da.",
+  "end_year": null,
+  "experiment": "Uniform hosing in the Labrador Sea.",
+  "min_number_yrs_per_sim": 50,
+  "parent_activity_id": [
+    "tipmip"
+  ],
+  "parent_experiment_id": [
+    "tipmip-ocn-p1t1-da"
+  ],
+  "required_model_components": [
+    "aogcm"
+  ],
+  "start_year": null,
+  "sub_experiment_id": [
+    "none"
+  ],
+  "tier": 1,
+  "drs_name": "tipmip-ocn-p1t1-Db"
+}

--- a/experiment/tipmip-ocn-p1t1-dc.json
+++ b/experiment/tipmip-ocn-p1t1-dc.json
@@ -1,0 +1,34 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tipmip-ocn-p1t1-dc",
+  "type": "experiment",
+  "experiment_id": "tipmip-ocn-p1t1-dc",
+  "activity_id": [
+    "tipmip"
+  ],
+  "additional_allowed_model_components": [
+    "aer",
+    "bgc",
+    "chem",
+    "ism"
+  ],
+  "description": "0 Sv freshwater branching from the ramp-down hosing in Db.",
+  "end_year": null,
+  "experiment": "No hosing in the Labrador Sea.",
+  "min_number_yrs_per_sim": 100,
+  "parent_activity_id": [
+    "tipmip"
+  ],
+  "parent_experiment_id": [
+    "tipmip-ocn-p1t1-db"
+  ],
+  "required_model_components": [
+    "aogcm"
+  ],
+  "start_year": null,
+  "sub_experiment_id": [
+    "none"
+  ],
+  "tier": 1,
+  "drs_name": "tipmip-ocn-p1t1-Dc"
+}

--- a/experiment/tipmip-ocn-p1t2-bb.json
+++ b/experiment/tipmip-ocn-p1t2-bb.json
@@ -1,0 +1,34 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tipmip-ocn-p1t2-bb",
+  "type": "experiment",
+  "experiment_id": "tipmip-ocn-p1t2-bb",
+  "activity_id": [
+    "tipmip"
+  ],
+  "additional_allowed_model_components": [
+    "aer",
+    "bgc",
+    "chem",
+    "ism"
+  ],
+  "description": "ScenarioMIP like SSP5-8.5 simulation starting on 2015 with additional Greenland Ice Sheet melting around Greenland.",
+  "end_year": null,
+  "experiment": "ScenarioMIP SSP5-8.5 with hosing around Greenland.",
+  "min_number_yrs_per_sim": 85,
+  "parent_activity_id": [
+    "tipmip"
+  ],
+  "parent_experiment_id": [
+    "tipmip-ocn-p1t1-ba"
+  ],
+  "required_model_components": [
+    "aogcm"
+  ],
+  "start_year": null,
+  "sub_experiment_id": [
+    "none"
+  ],
+  "tier": 2,
+  "drs_name": "tipmip-ocn-p1t2-Bb"
+}

--- a/experiment/tipmip-ocn-p1t2-ca.json
+++ b/experiment/tipmip-ocn-p1t2-ca.json
@@ -1,0 +1,34 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tipmip-ocn-p1t2-ca",
+  "type": "experiment",
+  "experiment_id": "tipmip-ocn-p1t2-ca",
+  "activity_id": [
+    "tipmip"
+  ],
+  "additional_allowed_model_components": [
+    "aer",
+    "bgc",
+    "chem",
+    "ism"
+  ],
+  "description": "Constant 0.3 Sv of water hosing over the North Atlantic and Arctiv North (North of 50 N) starting from a GWL2 stabilized run.",
+  "end_year": null,
+  "experiment": "NaHosMIP under GWL2",
+  "min_number_yrs_per_sim": 50,
+  "parent_activity_id": [
+    "tipmip"
+  ],
+  "parent_experiment_id": [
+    "esm-up2p0-gwl2p0"
+  ],
+  "required_model_components": [
+    "aogcm"
+  ],
+  "start_year": null,
+  "sub_experiment_id": [
+    "none"
+  ],
+  "tier": 2,
+  "drs_name": "tipmip-ocn-p1t2-Ca"
+}

--- a/experiment/tipmip-ocn-p1t2-cb.json
+++ b/experiment/tipmip-ocn-p1t2-cb.json
@@ -1,0 +1,34 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tipmip-ocn-p1t2-cb",
+  "type": "experiment",
+  "experiment_id": "tipmip-ocn-p1t2-cb",
+  "activity_id": [
+    "tipmip"
+  ],
+  "additional_allowed_model_components": [
+    "aer",
+    "bgc",
+    "chem",
+    "ism"
+  ],
+  "description": "Equivalent to NaHosMIP u03-r50 experiments (Jackson et al. 2023) in a warmer 2K world.",
+  "end_year": null,
+  "experiment": "No hosing, initialized from tipmip-ocn-p1t2-Ca.",
+  "min_number_yrs_per_sim": 100,
+  "parent_activity_id": [
+    "tipmip"
+  ],
+  "parent_experiment_id": [
+    "tipmip-ocn-p1t2-ca"
+  ],
+  "required_model_components": [
+    "aogcm"
+  ],
+  "start_year": null,
+  "sub_experiment_id": [
+    "none"
+  ],
+  "tier": 2,
+  "drs_name": "tipmip-ocn-p1t2-Cb"
+}


### PR DESCRIPTION
## Summary
Auto-generated by the [Consistency Watcher](https://github.com/ESPRI-Mod/github_repo_watcher) CI.

Missing universe terms were detected for **cmip6plus**.
These skeleton files need to be reviewed — **fill in placeholder values** before merging.

This PR is automatically updated daily if new terms are detected.

## Review checklist
- [ ] Check that generated term IDs are correct
- [ ] Fill in placeholder descriptions and fields
- [ ] Verify no duplicates with existing terms