### PR TITLE
Adding CORDEX-CMIP6 vertical_labels, temporal_labels and known_branded_variables

### DIFF
--- a/known_branded_variable/abs1000aer_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs1000aer_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs1000aer_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs1000aer_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs1000aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs1000aer_tpt-u-hxy-u.json
+++ b/known_branded_variable/abs1000aer_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs1000aer_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs1000aer_tpt-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs1000aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs1000bc_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs1000bc_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs1000bc_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs1000bc_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_black_carbon_ambient_aerosol",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs1000bc",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs1000dust_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs1000dust_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs1000dust_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs1000dust_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_dust_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs1000dust",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs1000nh4_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs1000nh4_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs1000nh4_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs1000nh4_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs1000nh4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs1000no3_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs1000no3_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs1000no3_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs1000no3_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_nitrate_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs1000no3",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs1000oa_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs1000oa_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs1000oa_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs1000oa_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_particulate_organic_matter_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs1000oa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs1000so4_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs1000so4_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs1000so4_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs1000so4_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_sulfate_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs1000so4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs1000ss_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs1000ss_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs1000ss_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs1000ss_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_sea_salt_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs1000ss",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs350aer_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs350aer_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs350aer_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs350aer_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs350aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs350aer_tpt-u-hxy-u.json
+++ b/known_branded_variable/abs350aer_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs350aer_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs350aer_tpt-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs350aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs350bc_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs350bc_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs350bc_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs350bc_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_black_carbon_ambient_aerosol",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs350bc",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs350dust_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs350dust_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs350dust_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs350dust_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_dust_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs350dust",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs350nh4_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs350nh4_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs350nh4_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs350nh4_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs350nh4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs350no3_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs350no3_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs350no3_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs350no3_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_nitrate_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs350no3",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs350oa_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs350oa_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs350oa_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs350oa_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_particulate_organic_matter_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs350oa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs350so4_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs350so4_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs350so4_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs350so4_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_sulfate_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs350so4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs350ss_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs350ss_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs350ss_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs350ss_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_sea_salt_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs350ss",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs440aer_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs440aer_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs440aer_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs440aer_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs440aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs440aer_tpt-u-hxy-u.json
+++ b/known_branded_variable/abs440aer_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs440aer_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs440aer_tpt-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs440aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs440bc_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs440bc_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs440bc_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs440bc_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_black_carbon_ambient_aerosol",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs440bc",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs440dust_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs440dust_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs440dust_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs440dust_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_dust_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs440dust",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs440nh4_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs440nh4_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs440nh4_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs440nh4_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs440nh4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs440no3_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs440no3_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs440no3_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs440no3_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_nitrate_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs440no3",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs440oa_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs440oa_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs440oa_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs440oa_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_particulate_organic_matter_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs440oa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs440so4_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs440so4_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs440so4_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs440so4_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_sulfate_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs440so4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs440ss_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs440ss_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs440ss_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs440ss_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_sea_salt_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs440ss",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs550aer_tpt-u-hxy-u.json
+++ b/known_branded_variable/abs550aer_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs550aer_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "1hr optional (considered for Tier1)",
+  "drs_name": "abs550aer_tpt-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs550aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs550nh4_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs550nh4_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs550nh4_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs550nh4_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs550nh4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs870aer_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs870aer_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs870aer_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs870aer_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs870aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs870aer_tpt-u-hxy-u.json
+++ b/known_branded_variable/abs870aer_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs870aer_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs870aer_tpt-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs870aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs870bc_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs870bc_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs870bc_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs870bc_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_black_carbon_ambient_aerosol",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs870bc",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs870dust_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs870dust_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs870dust_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs870dust_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_dust_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs870dust",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs870nh4_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs870nh4_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs870nh4_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs870nh4_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs870nh4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs870no3_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs870no3_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs870no3_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs870no3_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_nitrate_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs870no3",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs870oa_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs870oa_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs870oa_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs870oa_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_particulate_organic_matter_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs870oa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs870so4_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs870so4_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs870so4_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs870so4_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_sulfate_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs870so4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/abs870ss_tavg-u-hxy-u.json
+++ b/known_branded_variable/abs870ss_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "abs870ss_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "abs870ss_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_absorption_optical_thickness_due_to_sea_salt_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "abs870ss",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/asy1000aer_tavg-u-hxy-u.json
+++ b/known_branded_variable/asy1000aer_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "asy1000aer_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "asy1000aer_tavg-u-hxy-u",
+  "cf_standard_name": "asymmetry_factor_of_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "asy1000aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/asy1000aer_tpt-u-hxy-u.json
+++ b/known_branded_variable/asy1000aer_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "asy1000aer_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "asy1000aer_tpt-u-hxy-u",
+  "cf_standard_name": "asymmetry_factor_of_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "asy1000aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/asy350aer_tavg-u-hxy-u.json
+++ b/known_branded_variable/asy350aer_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "asy350aer_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "asy350aer_tavg-u-hxy-u",
+  "cf_standard_name": "asymmetry_factor_of_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "asy350aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/asy350aer_tpt-u-hxy-u.json
+++ b/known_branded_variable/asy350aer_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "asy350aer_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "asy350aer_tpt-u-hxy-u",
+  "cf_standard_name": "asymmetry_factor_of_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "asy350aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/asy440aer_tavg-u-hxy-u.json
+++ b/known_branded_variable/asy440aer_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "asy440aer_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "asy440aer_tavg-u-hxy-u",
+  "cf_standard_name": "asymmetry_factor_of_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "asy440aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/asy440aer_tpt-u-hxy-u.json
+++ b/known_branded_variable/asy440aer_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "asy440aer_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "asy440aer_tpt-u-hxy-u",
+  "cf_standard_name": "asymmetry_factor_of_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "asy440aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/asy550aer_tavg-u-hxy-u.json
+++ b/known_branded_variable/asy550aer_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "asy550aer_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "1hr optional (considered for Tier1)",
+  "drs_name": "asy550aer_tavg-u-hxy-u",
+  "cf_standard_name": "asymmetry_factor_of_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "asy550aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/asy550aer_tpt-u-hxy-u.json
+++ b/known_branded_variable/asy550aer_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "asy550aer_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "1hr optional (considered for Tier1)",
+  "drs_name": "asy550aer_tpt-u-hxy-u",
+  "cf_standard_name": "asymmetry_factor_of_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "asy550aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/asy870aer_tavg-u-hxy-u.json
+++ b/known_branded_variable/asy870aer_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "asy870aer_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "asy870aer_tavg-u-hxy-u",
+  "cf_standard_name": "asymmetry_factor_of_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "asy870aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/asy870aer_tpt-u-hxy-u.json
+++ b/known_branded_variable/asy870aer_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "asy870aer_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "asy870aer_tpt-u-hxy-u",
+  "cf_standard_name": "asymmetry_factor_of_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "asy870aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/cape_tavg-u-hxy-u.json
+++ b/known_branded_variable/cape_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "cape_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "cape_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_convective_available_potential_energy_wrt_surface",
+  "cf_units": "J kg-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "cape",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/cape_tmax-u-hxy-u.json
+++ b/known_branded_variable/cape_tmax-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "cape_tmax-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "cape_tmax-u-hxy-u",
+  "cf_standard_name": "atmosphere_convective_available_potential_energy_wrt_surface",
+  "cf_units": "J kg-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "cape",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tmax-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: mean time: maximum",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tmax",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/cape_tmaxavg-u-hxy-u.json
+++ b/known_branded_variable/cape_tmaxavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "cape_tmaxavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "cape_tmaxavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_convective_available_potential_energy_wrt_surface",
+  "cf_units": "J kg-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "cape",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tmaxavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: mean time: maximum within days time: mean over days",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tmaxavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/cape_tpt-u-hxy-u.json
+++ b/known_branded_variable/cape_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "cape_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "cape_tpt-u-hxy-u",
+  "cf_standard_name": "atmosphere_convective_available_potential_energy_wrt_surface",
+  "cf_units": "J kg-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "cape",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/cdnc_tavg-p19-hxy-u.json
+++ b/known_branded_variable/cdnc_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "cdnc_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "cdnc_tavg-p19-hxy-u",
+  "cf_standard_name": "number_concentration_of_cloud_liquid_water_particles_in_air",
+  "cf_units": "m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "cdnc",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/cdnc_tpt-p19-hxy-u.json
+++ b/known_branded_variable/cdnc_tpt-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "cdnc_tpt-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "cdnc_tpt-p19-hxy-u",
+  "cf_standard_name": "number_concentration_of_cloud_liquid_water_particles_in_air",
+  "cf_units": "m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "cdnc",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "plev19"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/cheaqpso4_tavg-p19-hxy-u.json
+++ b/known_branded_variable/cheaqpso4_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "cheaqpso4_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "cheaqpso4_tavg-p19-hxy-u",
+  "cf_standard_name": "tendency_of_atmosphere_mass_content_of_sulfate_dry_aerosol_particles_due_to_aqueous_phase_net_chemical_production",
+  "cf_units": "kg m-2 s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "cheaqpso4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/chegpso4_tavg-p19-hxy-u.json
+++ b/known_branded_variable/chegpso4_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "chegpso4_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "chegpso4_tavg-p19-hxy-u",
+  "cf_standard_name": "tendency_of_atmosphere_mass_content_of_sulfate_dry_aerosol_particles_due_to_gaseous_phase_net_chemical_production",
+  "cf_units": "kg m-2 s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "chegpso4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/chepnh4_tavg-p19-hxy-u.json
+++ b/known_branded_variable/chepnh4_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "chepnh4_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "chepnh4_tavg-p19-hxy-u",
+  "cf_standard_name": "tendency_of_atmosphere_mass_content_of_ammonium_dry_aerosol_particles_due_to_net_chemical_production",
+  "cf_units": "kg m-2 s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "chepnh4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/chepno3_tavg-p19-hxy-u.json
+++ b/known_branded_variable/chepno3_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "chepno3_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "chepno3_tavg-p19-hxy-u",
+  "cf_standard_name": "tendency_of_atmosphere_mass_content_of_nitrate_dry_aerosol_particles_due_to_net_chemical_production",
+  "cf_units": "kg m-2 s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "chepno3",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/chepsoa_tavg-p19-hxy-u.json
+++ b/known_branded_variable/chepsoa_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "chepsoa_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "chepsoa_tavg-p19-hxy-u",
+  "cf_standard_name": "tendency_of_atmosphere_mass_content_of_secondary_particulate_organic_matter_dry_aerosol_particles_due_to_net_chemical_production",
+  "cf_units": "kg m-2 s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "chepsoa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/cin_tavg-u-hxy-u.json
+++ b/known_branded_variable/cin_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "cin_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "cin_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_convective_inhibition_wrt_surface",
+  "cf_units": "J kg-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "cin",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/cin_tmax-u-hxy-u.json
+++ b/known_branded_variable/cin_tmax-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "cin_tmax-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "cin_tmax-u-hxy-u",
+  "cf_standard_name": "atmosphere_convective_inhibition_wrt_surface",
+  "cf_units": "J kg-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "cin",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tmax-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: mean time: maximum",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tmax",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/cin_tmaxavg-u-hxy-u.json
+++ b/known_branded_variable/cin_tmaxavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "cin_tmaxavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "cin_tmaxavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_convective_inhibition_wrt_surface",
+  "cf_units": "J kg-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "cin",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tmaxavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: mean time: maximum within days time: mean over days",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tmaxavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/cin_tpt-u-hxy-u.json
+++ b/known_branded_variable/cin_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "cin_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "cin_tpt-u-hxy-u",
+  "cf_standard_name": "atmosphere_convective_inhibition_wrt_surface",
+  "cf_units": "J kg-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "cin",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/clh_tavg-u-hxy-u.json
+++ b/known_branded_variable/clh_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "clh_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "clh_tavg-u-hxy-u",
+  "cf_standard_name": "cloud_area_fraction_in_atmosphere_layer",
+  "cf_units": "%",
+  "cf_sn_status": "approved",
+  "variable_root_name": "clh",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/cll_tavg-u-hxy-u.json
+++ b/known_branded_variable/cll_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "cll_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "cll_tavg-u-hxy-u",
+  "cf_standard_name": "cloud_area_fraction_in_atmosphere_layer",
+  "cf_units": "%",
+  "cf_sn_status": "approved",
+  "variable_root_name": "cll",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/clm_tavg-u-hxy-u.json
+++ b/known_branded_variable/clm_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "clm_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "clm_tavg-u-hxy-u",
+  "cf_standard_name": "cloud_area_fraction_in_atmosphere_layer",
+  "cf_units": "%",
+  "cf_sn_status": "approved",
+  "variable_root_name": "clm",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/concbc_tavg-p19-hxy-u.json
+++ b/known_branded_variable/concbc_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "concbc_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "concbc_tavg-p19-hxy-u",
+  "cf_standard_name": "mass_concentration_of_elemental_carbon_dry_aerosol_particles_in_air",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "concbc",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/concdust_tavg-p19-hxy-u.json
+++ b/known_branded_variable/concdust_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "concdust_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "concdust_tavg-p19-hxy-u",
+  "cf_standard_name": "mass_concentration_of_dust_dry_aerosol_particles_in_air",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "concdust",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/concnh4_tavg-p19-hxy-u.json
+++ b/known_branded_variable/concnh4_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "concnh4_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "concnh4_tavg-p19-hxy-u",
+  "cf_standard_name": "mass_concentration_of_ammonium_dry_aerosol_particles_in_air",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "concnh4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/concno3_tavg-p19-hxy-u.json
+++ b/known_branded_variable/concno3_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "concno3_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "concno3_tavg-p19-hxy-u",
+  "cf_standard_name": "mass_concentration_of_nitrate_dry_aerosol_particles_in_air",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "concno3",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/concoa_tavg-p19-hxy-u.json
+++ b/known_branded_variable/concoa_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "concoa_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "concoa_tavg-p19-hxy-u",
+  "cf_standard_name": "mass_concentration_of_particulate_organic_matter_dry_aerosol_particles_in_air",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "concoa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/concso4_tavg-p19-hxy-u.json
+++ b/known_branded_variable/concso4_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "concso4_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "concso4_tavg-p19-hxy-u",
+  "cf_standard_name": "mass_concentration_of_sulfate_dry_aerosol_particles_in_air",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "concso4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/concss_tavg-p19-hxy-u.json
+++ b/known_branded_variable/concss_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "concss_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "concss_tavg-p19-hxy-u",
+  "cf_standard_name": "mass_concentration_of_sea_salt_dry_aerosol_particles_in_air",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "concss",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/dtb_ti-u-hxy-u.json
+++ b/known_branded_variable/dtb_ti-u-hxy-u.json
@@ -1,0 +1,27 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "dtb_ti-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "dtb_ti-u-hxy-u",
+  "cf_standard_name": "bedrock_depth_below_ground_level",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "dtb",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "ti-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude"
+  ],
+  "cell_methods": "area: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "ti",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/eminh3_tmin-u-hxy-u.json
+++ b/known_branded_variable/eminh3_tmin-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "eminh3_tmin-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "daily output only if daily variations in emissions",
+  "drs_name": "eminh3_tmin-u-hxy-u",
+  "cf_standard_name": "tendency_of_atmosphere_mass_content_of_ammonia_due_to_emission",
+  "cf_units": "kg m-2 s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "eminh3",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tmin-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: mean time: minimum",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tmin",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/eminox_tmin-u-hxy-u.json
+++ b/known_branded_variable/eminox_tmin-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "eminox_tmin-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "daily output only if daily variations in emissions",
+  "drs_name": "eminox_tmin-u-hxy-u",
+  "cf_standard_name": "tendency_of_atmosphere_mass_content_of_nox_expressed_as_nitrogen_due_to_emission",
+  "cf_units": "kg m-2 s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "eminox",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tmin-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: mean time: minimum",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tmin",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/ext550aer_tavg-p19-hxy-u.json
+++ b/known_branded_variable/ext550aer_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ext550aer_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ext550aer_tavg-p19-hxy-u",
+  "cf_standard_name": "volume_extinction_coefficient_in_air_due_to_ambient_aerosol",
+  "cf_units": "m-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ext550aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ext550aer_tpt-p19-hxy-u.json
+++ b/known_branded_variable/ext550aer_tpt-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ext550aer_tpt-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ext550aer_tpt-p19-hxy-u",
+  "cf_standard_name": "volume_extinction_coefficient_in_air_due_to_ambient_aerosol",
+  "cf_units": "m-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ext550aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "plev19"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ext550bc_tavg-p19-hxy-u.json
+++ b/known_branded_variable/ext550bc_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ext550bc_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ext550bc_tavg-p19-hxy-u",
+  "cf_standard_name": "volume_extinction_coefficient_in_air_due_to_ambient_aerosol",
+  "cf_units": "m-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ext550bc",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ext550dust_tavg-p19-hxy-u.json
+++ b/known_branded_variable/ext550dust_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ext550dust_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ext550dust_tavg-p19-hxy-u",
+  "cf_standard_name": "volume_extinction_coefficient_in_air_due_to_ambient_aerosol",
+  "cf_units": "m-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ext550dust",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ext550nh4_tavg-p19-hxy-u.json
+++ b/known_branded_variable/ext550nh4_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ext550nh4_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ext550nh4_tavg-p19-hxy-u",
+  "cf_standard_name": "volume_extinction_coefficient_in_air_due_to_ambient_aerosol",
+  "cf_units": "m-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ext550nh4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ext550no3_tavg-p19-hxy-u.json
+++ b/known_branded_variable/ext550no3_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ext550no3_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ext550no3_tavg-p19-hxy-u",
+  "cf_standard_name": "volume_extinction_coefficient_in_air_due_to_ambient_aerosol",
+  "cf_units": "m-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ext550no3",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ext550oa_tavg-p19-hxy-u.json
+++ b/known_branded_variable/ext550oa_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ext550oa_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ext550oa_tavg-p19-hxy-u",
+  "cf_standard_name": "volume_extinction_coefficient_in_air_due_to_ambient_aerosol",
+  "cf_units": "m-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ext550oa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ext550so4_tavg-p19-hxy-u.json
+++ b/known_branded_variable/ext550so4_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ext550so4_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ext550so4_tavg-p19-hxy-u",
+  "cf_standard_name": "volume_extinction_coefficient_in_air_due_to_ambient_aerosol",
+  "cf_units": "m-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ext550so4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ext550ss_tavg-p19-hxy-u.json
+++ b/known_branded_variable/ext550ss_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ext550ss_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ext550ss_tavg-p19-hxy-u",
+  "cf_standard_name": "volume_extinction_coefficient_in_air_due_to_ambient_aerosol",
+  "cf_units": "m-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ext550ss",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hfcorr_tavg-u-hxy-sea.json
+++ b/known_branded_variable/hfcorr_tavg-u-hxy-sea.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hfcorr_tavg-u-hxy-sea",
+  "type": "known_branded_variable",
+  "description": "Flux correction is also called 'flux adjustment'. A positive flux correction is downward i.e. added to the ocean. In accordance with common usage in geophysical disciplines, 'flux' implies per unit area, called 'flux density' in physics.",
+  "drs_name": "hfcorr_tavg-u-hxy-sea",
+  "cf_standard_name": "heat_flux_correction",
+  "cf_units": "W m-2",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hfcorr",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-sea",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: mean where sea time: mean",
+  "cell_measures": "area: areacello",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "sea",
+  "bn_status": "accepted",
+  "positive_direction": "down"
+}

--- a/known_branded_variable/hus_tavg-1000hpa-hxy-u.json
+++ b/known_branded_variable/hus_tavg-1000hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tavg-1000hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tavg-1000hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-1000hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p1000"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "1000hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tavg-100hpa-hxy-u.json
+++ b/known_branded_variable/hus_tavg-100hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tavg-100hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tavg-100hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-100hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p100"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "100hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tavg-10hpa-hxy-u.json
+++ b/known_branded_variable/hus_tavg-10hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tavg-10hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tavg-10hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-10hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p10"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "10hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tavg-150hpa-hxy-u.json
+++ b/known_branded_variable/hus_tavg-150hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tavg-150hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tavg-150hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-150hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p150"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "150hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tavg-200hpa-hxy-u.json
+++ b/known_branded_variable/hus_tavg-200hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tavg-200hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tavg-200hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-200hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p200"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "200hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tavg-20hpa-hxy-u.json
+++ b/known_branded_variable/hus_tavg-20hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tavg-20hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tavg-20hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-20hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p20"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "20hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tavg-250hpa-hxy-u.json
+++ b/known_branded_variable/hus_tavg-250hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tavg-250hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tavg-250hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-250hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p250"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "250hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tavg-300hpa-hxy-u.json
+++ b/known_branded_variable/hus_tavg-300hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tavg-300hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tavg-300hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-300hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p300"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "300hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tavg-30hpa-hxy-u.json
+++ b/known_branded_variable/hus_tavg-30hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tavg-30hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tavg-30hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-30hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p30"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "30hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tavg-400hpa-hxy-u.json
+++ b/known_branded_variable/hus_tavg-400hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tavg-400hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tavg-400hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-400hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p400"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "400hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tavg-500hpa-hxy-u.json
+++ b/known_branded_variable/hus_tavg-500hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tavg-500hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tavg-500hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-500hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p500"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "500hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tavg-50hpa-hxy-u.json
+++ b/known_branded_variable/hus_tavg-50hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tavg-50hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tavg-50hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-50hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p50"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "50hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tavg-600hpa-hxy-u.json
+++ b/known_branded_variable/hus_tavg-600hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tavg-600hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tavg-600hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-600hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p600"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "600hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tavg-700hpa-hxy-u.json
+++ b/known_branded_variable/hus_tavg-700hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tavg-700hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tavg-700hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-700hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p700"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "700hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tavg-70hpa-hxy-u.json
+++ b/known_branded_variable/hus_tavg-70hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tavg-70hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tavg-70hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-70hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p70"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "70hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tavg-750hpa-hxy-u.json
+++ b/known_branded_variable/hus_tavg-750hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tavg-750hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tavg-750hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-750hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p750"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "750hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tavg-850hpa-hxy-u.json
+++ b/known_branded_variable/hus_tavg-850hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tavg-850hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "Specific humidity is the mass fraction of water vapor in (moist) air.",
+  "drs_name": "hus_tavg-850hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-850hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p850"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "850hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tavg-925hpa-hxy-u.json
+++ b/known_branded_variable/hus_tavg-925hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tavg-925hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tavg-925hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-925hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p925"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "925hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tavg-h50m-hxy-u.json
+++ b/known_branded_variable/hus_tavg-h50m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tavg-h50m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tavg-h50m-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-h50m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "height50m"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "h50m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tpt-1000hpa-hxy-u.json
+++ b/known_branded_variable/hus_tpt-1000hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tpt-1000hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tpt-1000hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-1000hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p1000"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "1000hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tpt-100hpa-hxy-u.json
+++ b/known_branded_variable/hus_tpt-100hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tpt-100hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tpt-100hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-100hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p100"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "100hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tpt-10hpa-hxy-u.json
+++ b/known_branded_variable/hus_tpt-10hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tpt-10hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tpt-10hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-10hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p10"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "10hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tpt-150hpa-hxy-u.json
+++ b/known_branded_variable/hus_tpt-150hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tpt-150hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tpt-150hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-150hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p150"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "150hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tpt-200hpa-hxy-u.json
+++ b/known_branded_variable/hus_tpt-200hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tpt-200hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tpt-200hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-200hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p200"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "200hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tpt-20hpa-hxy-u.json
+++ b/known_branded_variable/hus_tpt-20hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tpt-20hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tpt-20hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-20hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p20"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "20hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tpt-250hpa-hxy-u.json
+++ b/known_branded_variable/hus_tpt-250hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tpt-250hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tpt-250hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-250hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p250"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "250hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tpt-300hpa-hxy-u.json
+++ b/known_branded_variable/hus_tpt-300hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tpt-300hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tpt-300hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-300hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p300"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "300hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tpt-30hpa-hxy-u.json
+++ b/known_branded_variable/hus_tpt-30hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tpt-30hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tpt-30hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-30hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p30"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "30hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tpt-400hpa-hxy-u.json
+++ b/known_branded_variable/hus_tpt-400hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tpt-400hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tpt-400hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-400hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p400"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "400hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tpt-500hpa-hxy-u.json
+++ b/known_branded_variable/hus_tpt-500hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tpt-500hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tpt-500hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-500hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p500"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "500hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tpt-50hpa-hxy-u.json
+++ b/known_branded_variable/hus_tpt-50hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tpt-50hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tpt-50hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-50hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p50"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "50hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tpt-600hpa-hxy-u.json
+++ b/known_branded_variable/hus_tpt-600hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tpt-600hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tpt-600hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-600hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p600"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "600hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tpt-700hpa-hxy-u.json
+++ b/known_branded_variable/hus_tpt-700hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tpt-700hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tpt-700hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-700hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p700"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "700hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tpt-70hpa-hxy-u.json
+++ b/known_branded_variable/hus_tpt-70hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tpt-70hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tpt-70hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-70hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p70"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "70hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tpt-750hpa-hxy-u.json
+++ b/known_branded_variable/hus_tpt-750hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tpt-750hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tpt-750hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-750hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p750"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "750hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tpt-850hpa-hxy-u.json
+++ b/known_branded_variable/hus_tpt-850hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tpt-850hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tpt-850hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-850hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p850"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "850hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tpt-925hpa-hxy-u.json
+++ b/known_branded_variable/hus_tpt-925hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tpt-925hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tpt-925hPa-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-925hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p925"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "925hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/hus_tpt-h50m-hxy-u.json
+++ b/known_branded_variable/hus_tpt-h50m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "hus_tpt-h50m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "hus_tpt-h50m-hxy-u",
+  "cf_standard_name": "specific_humidity",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "hus",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-h50m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "height50m"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "h50m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/li_tavg-u-hxy-u.json
+++ b/known_branded_variable/li_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "li_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "li_tavg-u-hxy-u",
+  "cf_standard_name": "temperature_difference_between_ambient_air_and_air_lifted_adiabatically_from_the_surface",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "li",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/li_tmax-u-hxy-u.json
+++ b/known_branded_variable/li_tmax-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "li_tmax-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "li_tmax-u-hxy-u",
+  "cf_standard_name": "temperature_difference_between_ambient_air_and_air_lifted_adiabatically_from_the_surface",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "li",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tmax-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: mean time: maximum",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tmax",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/li_tmaxavg-u-hxy-u.json
+++ b/known_branded_variable/li_tmaxavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "li_tmaxavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "li_tmaxavg-u-hxy-u",
+  "cf_standard_name": "temperature_difference_between_ambient_air_and_air_lifted_adiabatically_from_the_surface",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "li",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tmaxavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: mean time: maximum within days time: mean over days",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tmaxavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/li_tpt-u-hxy-u.json
+++ b/known_branded_variable/li_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "li_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "li_tpt-u-hxy-u",
+  "cf_standard_name": "temperature_difference_between_ambient_air_and_air_lifted_adiabatically_from_the_surface",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "li",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/mrfso_tpt-u-hxy-lnd.json
+++ b/known_branded_variable/mrfso_tpt-u-hxy-lnd.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "mrfso_tpt-u-hxy-lnd",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "mrfso_tpt-u-hxy-lnd",
+  "cf_standard_name": "soil_frozen_water_content",
+  "cf_units": "kg m-2",
+  "cf_sn_status": "approved",
+  "variable_root_name": "mrfso",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-lnd",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean where land time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "lnd",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/mrfsos_tavg-u-hxy-lnd.json
+++ b/known_branded_variable/mrfsos_tavg-u-hxy-lnd.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "mrfsos_tavg-u-hxy-lnd",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "mrfsos_tavg-u-hxy-lnd",
+  "cf_standard_name": "frozen_water_content_of_soil_layer",
+  "cf_units": "kg m-2",
+  "cf_sn_status": "approved",
+  "variable_root_name": "mrfsos",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-lnd",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: mean where land time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "lnd",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/mrfsos_tpt-u-hxy-lnd.json
+++ b/known_branded_variable/mrfsos_tpt-u-hxy-lnd.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "mrfsos_tpt-u-hxy-lnd",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "mrfsos_tpt-u-hxy-lnd",
+  "cf_standard_name": "frozen_water_content_of_soil_layer",
+  "cf_units": "kg m-2",
+  "cf_sn_status": "approved",
+  "variable_root_name": "mrfsos",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-lnd",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean where land time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "lnd",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/mrsfl_tpt-sl-hxy-lnd.json
+++ b/known_branded_variable/mrsfl_tpt-sl-hxy-lnd.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "mrsfl_tpt-sl-hxy-lnd",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "mrsfl_tpt-sl-hxy-lnd",
+  "cf_standard_name": "frozen_water_content_of_soil_layer",
+  "cf_units": "kg m-2",
+  "cf_sn_status": "approved",
+  "variable_root_name": "mrsfl",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-sl-hxy-lnd",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "sdepth",
+    "time1"
+  ],
+  "cell_methods": "area: mean where land time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "sl",
+  "horizontal_label": "hxy",
+  "area_label": "lnd",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/mrso_tpt-u-hxy-lnd.json
+++ b/known_branded_variable/mrso_tpt-u-hxy-lnd.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "mrso_tpt-u-hxy-lnd",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "mrso_tpt-u-hxy-lnd",
+  "cf_standard_name": "mass_content_of_water_in_soil",
+  "cf_units": "kg m-2",
+  "cf_sn_status": "approved",
+  "variable_root_name": "mrso",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-lnd",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean where land time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "lnd",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/mrsol_tpt-sl-hxy-lnd.json
+++ b/known_branded_variable/mrsol_tpt-sl-hxy-lnd.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "mrsol_tpt-sl-hxy-lnd",
+  "type": "known_branded_variable",
+  "description": "in each soil layer, the mass of water in all phases, including ice.  Reported as 'missing' for grid cells occupied entirely by 'sea'",
+  "drs_name": "mrsol_tpt-sl-hxy-lnd",
+  "cf_standard_name": "mass_content_of_water_in_soil_layer",
+  "cf_units": "kg m-2",
+  "cf_sn_status": "approved",
+  "variable_root_name": "mrsol",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-sl-hxy-lnd",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "sdepth",
+    "time1"
+  ],
+  "cell_methods": "area: mean where land time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "sl",
+  "horizontal_label": "hxy",
+  "area_label": "lnd",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/mrsos_tavg-u-hxy-lnd.json
+++ b/known_branded_variable/mrsos_tavg-u-hxy-lnd.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "mrsos_tavg-u-hxy-lnd",
+  "type": "known_branded_variable",
+  "description": "The mass of water in all phases in the upper 10cm of the  soil layer.",
+  "drs_name": "mrsos_tavg-u-hxy-lnd",
+  "cf_standard_name": "mass_content_of_water_in_soil_layer",
+  "cf_units": "kg m-2",
+  "cf_sn_status": "approved",
+  "variable_root_name": "mrsos",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-lnd",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: mean where land time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "lnd",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/mrsos_tpt-u-hxy-lnd.json
+++ b/known_branded_variable/mrsos_tpt-u-hxy-lnd.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "mrsos_tpt-u-hxy-lnd",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "mrsos_tpt-u-hxy-lnd",
+  "cf_standard_name": "mass_content_of_water_in_soil_layer",
+  "cf_units": "kg m-2",
+  "cf_sn_status": "approved",
+  "variable_root_name": "mrsos",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-lnd",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean where land time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "lnd",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od1000aer_tavg-u-hxy-u.json
+++ b/known_branded_variable/od1000aer_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od1000aer_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od1000aer_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od1000aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od1000aer_tpt-u-hxy-u.json
+++ b/known_branded_variable/od1000aer_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od1000aer_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od1000aer_tpt-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od1000aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od1000bc_tavg-u-hxy-u.json
+++ b/known_branded_variable/od1000bc_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od1000bc_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od1000bc_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_black_carbon_ambient_aerosol",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od1000bc",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od1000dust_tavg-u-hxy-u.json
+++ b/known_branded_variable/od1000dust_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od1000dust_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od1000dust_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_dust_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od1000dust",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od1000nh4_tavg-u-hxy-u.json
+++ b/known_branded_variable/od1000nh4_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od1000nh4_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od1000nh4_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_ammonium_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od1000nh4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od1000no3_tavg-u-hxy-u.json
+++ b/known_branded_variable/od1000no3_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od1000no3_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od1000no3_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_nitrate_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od1000no3",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od1000oa_tavg-u-hxy-u.json
+++ b/known_branded_variable/od1000oa_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od1000oa_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od1000oa_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_particulate_organic_matter_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od1000oa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od1000so4_tavg-u-hxy-u.json
+++ b/known_branded_variable/od1000so4_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od1000so4_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od1000so4_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_sulfate_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od1000so4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od1000ss_tavg-u-hxy-u.json
+++ b/known_branded_variable/od1000ss_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od1000ss_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od1000ss_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_sea_salt_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od1000ss",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od350aer_tavg-u-hxy-u.json
+++ b/known_branded_variable/od350aer_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od350aer_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od350aer_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od350aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od350aer_tpt-u-hxy-u.json
+++ b/known_branded_variable/od350aer_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od350aer_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od350aer_tpt-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od350aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od350bc_tavg-u-hxy-u.json
+++ b/known_branded_variable/od350bc_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od350bc_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od350bc_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_black_carbon_ambient_aerosol",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od350bc",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od350dust_tavg-u-hxy-u.json
+++ b/known_branded_variable/od350dust_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od350dust_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od350dust_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_dust_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od350dust",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od350nh4_tavg-u-hxy-u.json
+++ b/known_branded_variable/od350nh4_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od350nh4_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od350nh4_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_ammonium_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od350nh4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od350no3_tavg-u-hxy-u.json
+++ b/known_branded_variable/od350no3_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od350no3_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od350no3_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_nitrate_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od350no3",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od350oa_tavg-u-hxy-u.json
+++ b/known_branded_variable/od350oa_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od350oa_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od350oa_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_particulate_organic_matter_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od350oa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od350so4_tavg-u-hxy-u.json
+++ b/known_branded_variable/od350so4_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od350so4_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od350so4_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_sulfate_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od350so4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od350ss_tavg-u-hxy-u.json
+++ b/known_branded_variable/od350ss_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od350ss_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od350ss_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_sea_salt_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od350ss",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od440aer_tavg-u-hxy-u.json
+++ b/known_branded_variable/od440aer_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od440aer_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od440aer_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od440aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od440aer_tpt-u-hxy-u.json
+++ b/known_branded_variable/od440aer_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od440aer_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od440aer_tpt-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od440aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od440bc_tavg-u-hxy-u.json
+++ b/known_branded_variable/od440bc_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od440bc_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od440bc_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_black_carbon_ambient_aerosol",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od440bc",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od440dust_tavg-u-hxy-u.json
+++ b/known_branded_variable/od440dust_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od440dust_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od440dust_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_dust_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od440dust",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od440nh4_tavg-u-hxy-u.json
+++ b/known_branded_variable/od440nh4_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od440nh4_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od440nh4_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_ammonium_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od440nh4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od440no3_tavg-u-hxy-u.json
+++ b/known_branded_variable/od440no3_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od440no3_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od440no3_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_nitrate_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od440no3",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od440oa_tavg-u-hxy-u.json
+++ b/known_branded_variable/od440oa_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od440oa_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od440oa_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_particulate_organic_matter_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od440oa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od440so4_tavg-u-hxy-u.json
+++ b/known_branded_variable/od440so4_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od440so4_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od440so4_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_sulfate_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od440so4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od440ss_tavg-u-hxy-u.json
+++ b/known_branded_variable/od440ss_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od440ss_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od440ss_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_sea_salt_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od440ss",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od550aer_tpt-u-hxy-u.json
+++ b/known_branded_variable/od550aer_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od550aer_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "AOD from the ambient aerosols (i.e., includes aerosol water).  Does not include AOD from stratospheric aerosols if these are prescribed but includes other possible background aerosol types. Needs a comment attribute 'wavelength: 550nm'",
+  "drs_name": "od550aer_tpt-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od550aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od550bc_tpt-u-hxy-u.json
+++ b/known_branded_variable/od550bc_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od550bc_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "1hr optional (considered for Tier1)",
+  "drs_name": "od550bc_tpt-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_black_carbon_ambient_aerosol",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od550bc",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od550dust_tpt-u-hxy-u.json
+++ b/known_branded_variable/od550dust_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od550dust_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "1hr optional (considered for Tier1)",
+  "drs_name": "od550dust_tpt-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_dust_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od550dust",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od550lt1aer_tpt-u-hxy-u.json
+++ b/known_branded_variable/od550lt1aer_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od550lt1aer_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od550lt1aer_tpt-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_pm1_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od550lt1aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od550nh4_tavg-u-hxy-u.json
+++ b/known_branded_variable/od550nh4_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od550nh4_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "1hr optional (considered for Tier1)",
+  "drs_name": "od550nh4_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_ammonium_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od550nh4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od550nh4_tpt-u-hxy-u.json
+++ b/known_branded_variable/od550nh4_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od550nh4_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "1hr optional (considered for Tier1)",
+  "drs_name": "od550nh4_tpt-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_ammonium_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od550nh4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od550no3_tpt-u-hxy-u.json
+++ b/known_branded_variable/od550no3_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od550no3_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "1hr optional (considered for Tier1)",
+  "drs_name": "od550no3_tpt-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_nitrate_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od550no3",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od550oa_tpt-u-hxy-u.json
+++ b/known_branded_variable/od550oa_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od550oa_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "1hr optional (considered for Tier1)",
+  "drs_name": "od550oa_tpt-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_particulate_organic_matter_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od550oa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od550so4_tpt-u-hxy-u.json
+++ b/known_branded_variable/od550so4_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od550so4_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "1hr optional (considered for Tier1)",
+  "drs_name": "od550so4_tpt-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_sulfate_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od550so4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od550soa_tpt-u-hxy-u.json
+++ b/known_branded_variable/od550soa_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od550soa_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od550soa_tpt-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_particulate_organic_matter_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od550soa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od550ss_tpt-u-hxy-u.json
+++ b/known_branded_variable/od550ss_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od550ss_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "1hr optional (considered for Tier1)",
+  "drs_name": "od550ss_tpt-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_sea_salt_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od550ss",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od870aer_tavg-u-hxy-u.json
+++ b/known_branded_variable/od870aer_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od870aer_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od870aer_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od870aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od870aer_tpt-u-hxy-u.json
+++ b/known_branded_variable/od870aer_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od870aer_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od870aer_tpt-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od870aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od870bc_tavg-u-hxy-u.json
+++ b/known_branded_variable/od870bc_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od870bc_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od870bc_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_black_carbon_ambient_aerosol",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od870bc",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od870dust_tavg-u-hxy-u.json
+++ b/known_branded_variable/od870dust_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od870dust_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od870dust_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_dust_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od870dust",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od870nh4_tavg-u-hxy-u.json
+++ b/known_branded_variable/od870nh4_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od870nh4_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od870nh4_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_ammonium_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od870nh4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od870no3_tavg-u-hxy-u.json
+++ b/known_branded_variable/od870no3_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od870no3_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od870no3_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_nitrate_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od870no3",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od870oa_tavg-u-hxy-u.json
+++ b/known_branded_variable/od870oa_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od870oa_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od870oa_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_particulate_organic_matter_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od870oa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od870so4_tavg-u-hxy-u.json
+++ b/known_branded_variable/od870so4_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od870so4_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od870so4_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_sulfate_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od870so4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/od870ss_tavg-u-hxy-u.json
+++ b/known_branded_variable/od870ss_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "od870ss_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "od870ss_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_optical_thickness_due_to_sea_salt_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "od870ss",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/prh_tavgmax-u-hxy-u.json
+++ b/known_branded_variable/prh_tavgmax-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "prh_tavgmax-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "In accordance with common usage in geophysical disciplines, 'flux' implies per unit area, called 'flux density' in physics.",
+  "drs_name": "prh_tavgmax-u-hxy-u",
+  "cf_standard_name": "precipitation_flux",
+  "cf_units": "kg m-2 s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "prh",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavgmax-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: mean time: mean within hours time: maximum over hours",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavgmax",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/rhop_tavg-u-hxy-sea.json
+++ b/known_branded_variable/rhop_tavg-u-hxy-sea.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "rhop_tavg-u-hxy-sea",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "rhop_tavg-u-hxy-sea",
+  "cf_standard_name": "sea_water_potential_density",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "rhop",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-sea",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: mean where sea time: mean",
+  "cell_measures": "",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "sea",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/rldsaf_tavg-u-hxy-u.json
+++ b/known_branded_variable/rldsaf_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "rldsaf_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "rldsaf_tavg-u-hxy-u",
+  "cf_standard_name": "surface_downwelling_longwave_flux_in_air",
+  "cf_units": "W m-2",
+  "cf_sn_status": "approved",
+  "variable_root_name": "rldsaf",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "down"
+}

--- a/known_branded_variable/rldscsaf_tavg-u-hxy-u.json
+++ b/known_branded_variable/rldscsaf_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "rldscsaf_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "rldscsaf_tavg-u-hxy-u",
+  "cf_standard_name": "surface_downwelling_longwave_flux_in_air_assuming_clear_sky",
+  "cf_units": "W m-2",
+  "cf_sn_status": "approved",
+  "variable_root_name": "rldscsaf",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "down"
+}

--- a/known_branded_variable/rlusaf_tavg-u-hxy-u.json
+++ b/known_branded_variable/rlusaf_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "rlusaf_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "rlusaf_tavg-u-hxy-u",
+  "cf_standard_name": "surface_upwelling_longwave_flux_in_air",
+  "cf_units": "W m-2",
+  "cf_sn_status": "approved",
+  "variable_root_name": "rlusaf",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/rootd_ti-u-hxy-u.json
+++ b/known_branded_variable/rootd_ti-u-hxy-u.json
@@ -1,0 +1,27 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "rootd_ti-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "report the maximum soil depth reachable by plant roots (if defined in model), i.e., the maximum soil depth from which they can extract moisture; report as *missing* where the land fraction is 0.",
+  "drs_name": "rootd_ti-u-hxy-u",
+  "cf_standard_name": "root_depth",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "rootd",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "ti-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude"
+  ],
+  "cell_methods": "area: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "ti",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/rsdsaf_tavg-u-hxy-u.json
+++ b/known_branded_variable/rsdsaf_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "rsdsaf_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "rsdsaf_tavg-u-hxy-u",
+  "cf_standard_name": "surface_downwelling_shortwave_flux_in_air",
+  "cf_units": "W m-2",
+  "cf_sn_status": "approved",
+  "variable_root_name": "rsdsaf",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "down"
+}

--- a/known_branded_variable/rsdscsaf_tavg-u-hxy-u.json
+++ b/known_branded_variable/rsdscsaf_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "rsdscsaf_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "rsdscsaf_tavg-u-hxy-u",
+  "cf_standard_name": "surface_downwelling_shortwave_flux_in_air_assuming_clear_sky_and_no_aerosol",
+  "cf_units": "W m-2",
+  "cf_sn_status": "approved",
+  "variable_root_name": "rsdscsaf",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "down"
+}

--- a/known_branded_variable/rsdsdir_tavg-u-hxy-u.json
+++ b/known_branded_variable/rsdsdir_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "rsdsdir_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "rsdsdir_tavg-u-hxy-u",
+  "cf_standard_name": "surface_direct_downwelling_shortwave_flux_in_air",
+  "cf_units": "W m-2",
+  "cf_sn_status": "approved",
+  "variable_root_name": "rsdsdir",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "down"
+}

--- a/known_branded_variable/rsusaf_tavg-u-hxy-u.json
+++ b/known_branded_variable/rsusaf_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "rsusaf_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "rsusaf_tavg-u-hxy-u",
+  "cf_standard_name": "surface_upwelling_shortwave_flux_in_air",
+  "cf_units": "W m-2",
+  "cf_sn_status": "approved",
+  "variable_root_name": "rsusaf",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/rsuscsaf_tavg-u-hxy-u.json
+++ b/known_branded_variable/rsuscsaf_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "rsuscsaf_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "rsuscsaf_tavg-u-hxy-u",
+  "cf_standard_name": "surface_upwelling_shortwave_flux_in_air_assuming_clear_sky_and_no_aerosol",
+  "cf_units": "W m-2",
+  "cf_sn_status": "approved",
+  "variable_root_name": "rsuscsaf",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/scat550aer_tavg-p19-hxy-u.json
+++ b/known_branded_variable/scat550aer_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "scat550aer_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "scat550aer_tavg-p19-hxy-u",
+  "cf_standard_name": "volume_scattering_coefficient_in_air_due_to_ambient_aerosol_particles",
+  "cf_units": "m-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "scat550aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/scat550aer_tpt-p19-hxy-u.json
+++ b/known_branded_variable/scat550aer_tpt-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "scat550aer_tpt-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "scat550aer_tpt-p19-hxy-u",
+  "cf_standard_name": "volume_scattering_coefficient_in_air_due_to_ambient_aerosol_particles",
+  "cf_units": "m-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "scat550aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "plev19"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/scat550bc_tavg-p19-hxy-u.json
+++ b/known_branded_variable/scat550bc_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "scat550bc_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "scat550bc_tavg-p19-hxy-u",
+  "cf_standard_name": "volume_scattering_coefficient_in_air_due_to_ambient_aerosol_particles",
+  "cf_units": "m-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "scat550bc",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/scat550dust_tavg-p19-hxy-u.json
+++ b/known_branded_variable/scat550dust_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "scat550dust_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "scat550dust_tavg-p19-hxy-u",
+  "cf_standard_name": "volume_scattering_coefficient_in_air_due_to_ambient_aerosol_particles",
+  "cf_units": "m-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "scat550dust",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/scat550nh4_tavg-p19-hxy-u.json
+++ b/known_branded_variable/scat550nh4_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "scat550nh4_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "scat550nh4_tavg-p19-hxy-u",
+  "cf_standard_name": "volume_scattering_coefficient_in_air_due_to_ambient_aerosol_particles",
+  "cf_units": "m-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "scat550nh4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/scat550no3_tavg-p19-hxy-u.json
+++ b/known_branded_variable/scat550no3_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "scat550no3_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "scat550no3_tavg-p19-hxy-u",
+  "cf_standard_name": "volume_scattering_coefficient_in_air_due_to_ambient_aerosol_particles",
+  "cf_units": "m-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "scat550no3",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/scat550oa_tavg-p19-hxy-u.json
+++ b/known_branded_variable/scat550oa_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "scat550oa_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "scat550oa_tavg-p19-hxy-u",
+  "cf_standard_name": "volume_scattering_coefficient_in_air_due_to_ambient_aerosol_particles",
+  "cf_units": "m-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "scat550oa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/scat550so4_tavg-p19-hxy-u.json
+++ b/known_branded_variable/scat550so4_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "scat550so4_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "scat550so4_tavg-p19-hxy-u",
+  "cf_standard_name": "volume_scattering_coefficient_in_air_due_to_ambient_aerosol_particles",
+  "cf_units": "m-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "scat550so4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/scat550ss_tavg-p19-hxy-u.json
+++ b/known_branded_variable/scat550ss_tavg-p19-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "scat550ss_tavg-p19-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "scat550ss_tavg-p19-hxy-u",
+  "cf_standard_name": "volume_scattering_coefficient_in_air_due_to_ambient_aerosol_particles",
+  "cf_units": "m-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "scat550ss",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-p19-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "plev19"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "p19",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/sconcbc_tavg-u-hxy-u.json
+++ b/known_branded_variable/sconcbc_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sconcbc_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "sconcbc_tavg-u-hxy-u",
+  "cf_standard_name": "mass_concentration_of_elemental_carbon_dry_aerosol_particles_in_air",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sconcbc",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/sconcbc_tpt-u-hxy-u.json
+++ b/known_branded_variable/sconcbc_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sconcbc_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "sconcbc_tpt-u-hxy-u",
+  "cf_standard_name": "mass_concentration_of_elemental_carbon_dry_aerosol_particles_in_air",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sconcbc",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/sconcdust_tavg-u-hxy-u.json
+++ b/known_branded_variable/sconcdust_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sconcdust_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "sconcdust_tavg-u-hxy-u",
+  "cf_standard_name": "mass_concentration_of_dust_dry_aerosol_particles_in_air",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sconcdust",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/sconcdust_tpt-u-hxy-u.json
+++ b/known_branded_variable/sconcdust_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sconcdust_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "sconcdust_tpt-u-hxy-u",
+  "cf_standard_name": "mass_concentration_of_dust_dry_aerosol_particles_in_air",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sconcdust",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/sconcnh4_tavg-u-hxy-u.json
+++ b/known_branded_variable/sconcnh4_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sconcnh4_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "sconcnh4_tavg-u-hxy-u",
+  "cf_standard_name": "mass_concentration_of_ammonium_dry_aerosol_particles_in_air",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sconcnh4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/sconcnh4_tpt-u-hxy-u.json
+++ b/known_branded_variable/sconcnh4_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sconcnh4_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "sconcnh4_tpt-u-hxy-u",
+  "cf_standard_name": "mass_concentration_of_ammonium_dry_aerosol_particles_in_air",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sconcnh4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/sconcno3_tavg-u-hxy-u.json
+++ b/known_branded_variable/sconcno3_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sconcno3_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "sconcno3_tavg-u-hxy-u",
+  "cf_standard_name": "mass_concentration_of_nitrate_dry_aerosol_particles_in_air",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sconcno3",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/sconcno3_tpt-u-hxy-u.json
+++ b/known_branded_variable/sconcno3_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sconcno3_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "sconcno3_tpt-u-hxy-u",
+  "cf_standard_name": "mass_concentration_of_nitrate_dry_aerosol_particles_in_air",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sconcno3",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/sconcoa_tavg-u-hxy-u.json
+++ b/known_branded_variable/sconcoa_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sconcoa_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "sconcoa_tavg-u-hxy-u",
+  "cf_standard_name": "mass_concentration_of_particulate_organic_matter_dry_aerosol_particles_in_air",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sconcoa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/sconcoa_tpt-u-hxy-u.json
+++ b/known_branded_variable/sconcoa_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sconcoa_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "sconcoa_tpt-u-hxy-u",
+  "cf_standard_name": "mass_concentration_of_particulate_organic_matter_dry_aerosol_particles_in_air",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sconcoa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/sconcso4_tavg-u-hxy-u.json
+++ b/known_branded_variable/sconcso4_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sconcso4_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "sconcso4_tavg-u-hxy-u",
+  "cf_standard_name": "mass_concentration_of_sulfate_dry_aerosol_particles_in_air",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sconcso4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/sconcso4_tpt-u-hxy-u.json
+++ b/known_branded_variable/sconcso4_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sconcso4_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "sconcso4_tpt-u-hxy-u",
+  "cf_standard_name": "mass_concentration_of_sulfate_dry_aerosol_particles_in_air",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sconcso4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/sconcsoa_tavg-u-hxy-u.json
+++ b/known_branded_variable/sconcsoa_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sconcsoa_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "sconcsoa_tavg-u-hxy-u",
+  "cf_standard_name": "mass_concentration_of_secondary_particulate_organic_matter_dry_aerosol_particles_in_air",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sconcsoa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/sconcsoa_tpt-u-hxy-u.json
+++ b/known_branded_variable/sconcsoa_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sconcsoa_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "sconcsoa_tpt-u-hxy-u",
+  "cf_standard_name": "mass_concentration_of_secondary_particulate_organic_matter_dry_aerosol_particles_in_air",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sconcsoa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/sconcss_tavg-u-hxy-u.json
+++ b/known_branded_variable/sconcss_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sconcss_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "sconcss_tavg-u-hxy-u",
+  "cf_standard_name": "mass_concentration_of_sea_salt_dry_aerosol_particles_in_air",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sconcss",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/sconcss_tpt-u-hxy-u.json
+++ b/known_branded_variable/sconcss_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sconcss_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "sconcss_tpt-u-hxy-u",
+  "cf_standard_name": "mass_concentration_of_sea_salt_dry_aerosol_particles_in_air",
+  "cf_units": "kg m-3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sconcss",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/sedbc_tavg-u-hxy-u.json
+++ b/known_branded_variable/sedbc_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sedbc_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "only if sedimentation is applied for this aerosol",
+  "drs_name": "sedbc_tavg-u-hxy-u",
+  "cf_standard_name": "minus_tendency_of_atmosphere_mass_content_of_elemental_carbon_dry_aerosol_particles_due_to_dry_deposition",
+  "cf_units": "kg m-2 s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sedbc",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "down"
+}

--- a/known_branded_variable/seddust_tavg-u-hxy-u.json
+++ b/known_branded_variable/seddust_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "seddust_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "only if sedimentation is applied for this aerosol",
+  "drs_name": "seddust_tavg-u-hxy-u",
+  "cf_standard_name": "minus_tendency_of_atmosphere_mass_content_of_dust_dry_aerosol_particles_due_to_dry_deposition",
+  "cf_units": "kg m-2 s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "seddust",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "down"
+}

--- a/known_branded_variable/sednh4_tavg-u-hxy-u.json
+++ b/known_branded_variable/sednh4_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sednh4_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "only if sedimentation is applied for this aerosol",
+  "drs_name": "sednh4_tavg-u-hxy-u",
+  "cf_standard_name": "minus_tendency_of_atmosphere_mass_content_of_ammonium_dry_aerosol_particles_due_to_dry_deposition",
+  "cf_units": "kg m-2 s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sednh4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "down"
+}

--- a/known_branded_variable/sedno3_tavg-u-hxy-u.json
+++ b/known_branded_variable/sedno3_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sedno3_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "only if sedimentation is applied for this aerosol",
+  "drs_name": "sedno3_tavg-u-hxy-u",
+  "cf_standard_name": "tendency_of_atmosphere_mass_content_of_nitrate_dry_aerosol_particles_due_to_dry_deposition",
+  "cf_units": "kg m-2 s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sedno3",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "down"
+}

--- a/known_branded_variable/sedoa_tavg-u-hxy-u.json
+++ b/known_branded_variable/sedoa_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sedoa_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "only if sedimentation is applied for this aerosol",
+  "drs_name": "sedoa_tavg-u-hxy-u",
+  "cf_standard_name": "minus_tendency_of_atmosphere_mass_content_of_particulate_organic_matter_dry_aerosol_particles_due_to_dry_deposition",
+  "cf_units": "kg m-2 s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sedoa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "down"
+}

--- a/known_branded_variable/sedso4_tavg-u-hxy-u.json
+++ b/known_branded_variable/sedso4_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sedso4_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "only if sedimentation is applied for this aerosol",
+  "drs_name": "sedso4_tavg-u-hxy-u",
+  "cf_standard_name": "minus_tendency_of_atmosphere_mass_content_of_sulfate_dry_aerosol_particles_due_to_dry_deposition",
+  "cf_units": "kg m-2 s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sedso4",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "down"
+}

--- a/known_branded_variable/sedss_tavg-u-hxy-u.json
+++ b/known_branded_variable/sedss_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sedss_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "only if sedimentation is applied for this aerosol",
+  "drs_name": "sedss_tavg-u-hxy-u",
+  "cf_standard_name": "minus_tendency_of_atmosphere_mass_content_of_sea_salt_dry_aerosol_particles_due_to_dry_deposition",
+  "cf_units": "kg m-2 s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sedss",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "down"
+}

--- a/known_branded_variable/sfcwind_tpt-h10m-hxy-u.json
+++ b/known_branded_variable/sfcwind_tpt-h10m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sfcwind_tpt-h10m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "sfcWind_tpt-h10m-hxy-u",
+  "cf_standard_name": "wind_speed",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sfcWind",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-h10m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "height10m"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "h10m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/sfturf_tavg-u-hxy-u.json
+++ b/known_branded_variable/sfturf_tavg-u-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sfturf_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "sfturf_tavg-u-hxy-u",
+  "cf_standard_name": "area_fraction",
+  "cf_units": "%",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sfturf",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "typeurban"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/sfturf_ti-u-hxy-u.json
+++ b/known_branded_variable/sfturf_ti-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sfturf_ti-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "sfturf_ti-u-hxy-u",
+  "cf_standard_name": "area_fraction",
+  "cf_units": "%",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sfturf",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "ti-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "typeurban"
+  ],
+  "cell_methods": "area: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "ti",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/siconc_tavg-u-hxy-sea.json
+++ b/known_branded_variable/siconc_tavg-u-hxy-sea.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "siconc_tavg-u-hxy-sea",
+  "type": "known_branded_variable",
+  "description": "Percentage of grid cell covered by sea ice",
+  "drs_name": "siconc_tavg-u-hxy-sea",
+  "cf_standard_name": "sea_ice_area_fraction",
+  "cf_units": "%",
+  "cf_sn_status": "approved",
+  "variable_root_name": "siconc",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-sea",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: mean where sea time: mean",
+  "cell_measures": "area: areacello",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "sea",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/sitemptop_tavg-u-hxy-si.json
+++ b/known_branded_variable/sitemptop_tavg-u-hxy-si.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sitemptop_tavg-u-hxy-si",
+  "type": "known_branded_variable",
+  "description": "Report surface temperature of snow where snow covers the sea ice.",
+  "drs_name": "sitemptop_tavg-u-hxy-si",
+  "cf_standard_name": "sea_ice_surface_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sitemptop",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-si",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean where sea_ice (comment: mask=siconc)",
+  "cell_measures": "area: areacello",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "si",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/snc_tavg-u-hxy-u.json
+++ b/known_branded_variable/snc_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "snc_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "Percentage of each grid cell that is occupied by snow that rests on land portion of cell.",
+  "drs_name": "snc_tavg-u-hxy-u",
+  "cf_standard_name": "surface_snow_area_fraction",
+  "cf_units": "%",
+  "cf_sn_status": "approved",
+  "variable_root_name": "snc",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/snc_tpt-u-hxy-u.json
+++ b/known_branded_variable/snc_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "snc_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "Percentage of each grid cell that is occupied by snow that rests on land portion of cell.",
+  "drs_name": "snc_tpt-u-hxy-u",
+  "cf_standard_name": "surface_snow_area_fraction",
+  "cf_units": "%",
+  "cf_sn_status": "approved",
+  "variable_root_name": "snc",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/snd_tpt-u-hxy-lnd.json
+++ b/known_branded_variable/snd_tpt-u-hxy-lnd.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "snd_tpt-u-hxy-lnd",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "snd_tpt-u-hxy-lnd",
+  "cf_standard_name": "surface_snow_thickness",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "snd",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-lnd",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean where land time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "lnd",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/snw_tpt-u-hxy-lnd.json
+++ b/known_branded_variable/snw_tpt-u-hxy-lnd.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "snw_tpt-u-hxy-lnd",
+  "type": "known_branded_variable",
+  "description": "The mass of surface snow on the land portion of the grid cell divided by the land area in the grid cell; reported as missing where the land fraction is 0; excludes snow on vegetation canopy or on sea ice.",
+  "drs_name": "snw_tpt-u-hxy-lnd",
+  "cf_standard_name": "surface_snow_amount",
+  "cf_units": "kg m-2",
+  "cf_sn_status": "approved",
+  "variable_root_name": "snw",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-lnd",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean where land time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "lnd",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ssa1000aer_tavg-u-hxy-u.json
+++ b/known_branded_variable/ssa1000aer_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ssa1000aer_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ssa1000aer_tavg-u-hxy-u",
+  "cf_standard_name": "single_scattering_albedo_in_air_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ssa1000aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ssa1000aer_tpt-u-hxy-u.json
+++ b/known_branded_variable/ssa1000aer_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ssa1000aer_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ssa1000aer_tpt-u-hxy-u",
+  "cf_standard_name": "single_scattering_albedo_in_air_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ssa1000aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ssa350aer_tavg-u-hxy-u.json
+++ b/known_branded_variable/ssa350aer_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ssa350aer_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ssa350aer_tavg-u-hxy-u",
+  "cf_standard_name": "single_scattering_albedo_in_air_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ssa350aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ssa350aer_tpt-u-hxy-u.json
+++ b/known_branded_variable/ssa350aer_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ssa350aer_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ssa350aer_tpt-u-hxy-u",
+  "cf_standard_name": "single_scattering_albedo_in_air_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ssa350aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ssa440aer_tavg-u-hxy-u.json
+++ b/known_branded_variable/ssa440aer_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ssa440aer_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ssa440aer_tavg-u-hxy-u",
+  "cf_standard_name": "single_scattering_albedo_in_air_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ssa440aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ssa440aer_tpt-u-hxy-u.json
+++ b/known_branded_variable/ssa440aer_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ssa440aer_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ssa440aer_tpt-u-hxy-u",
+  "cf_standard_name": "single_scattering_albedo_in_air_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ssa440aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ssa550aer_tavg-u-hxy-u.json
+++ b/known_branded_variable/ssa550aer_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ssa550aer_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "1hr optional (considered for Tier1)",
+  "drs_name": "ssa550aer_tavg-u-hxy-u",
+  "cf_standard_name": "single_scattering_albedo_in_air_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ssa550aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ssa550aer_tpt-u-hxy-u.json
+++ b/known_branded_variable/ssa550aer_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ssa550aer_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "1hr optional (considered for Tier1)",
+  "drs_name": "ssa550aer_tpt-u-hxy-u",
+  "cf_standard_name": "single_scattering_albedo_in_air_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ssa550aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ssa870aer_tavg-u-hxy-u.json
+++ b/known_branded_variable/ssa870aer_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ssa870aer_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ssa870aer_tavg-u-hxy-u",
+  "cf_standard_name": "single_scattering_albedo_in_air_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ssa870aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ssa870aer_tpt-u-hxy-u.json
+++ b/known_branded_variable/ssa870aer_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ssa870aer_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ssa870aer_tpt-u-hxy-u",
+  "cf_standard_name": "single_scattering_albedo_in_air_due_to_ambient_aerosol_particles",
+  "cf_units": "1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ssa870aer",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/sund_tsum-u-hxy-u.json
+++ b/known_branded_variable/sund_tsum-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sund_tsum-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "sund_tsum-u-hxy-u",
+  "cf_standard_name": "duration_of_sunshine",
+  "cf_units": "s",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sund",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tsum-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "time: sum",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tsum",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/sund_tsumavg-u-hxy-u.json
+++ b/known_branded_variable/sund_tsumavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sund_tsumavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "sund_tsumavg-u-hxy-u",
+  "cf_standard_name": "duration_of_sunshine",
+  "cf_units": "s",
+  "cf_sn_status": "approved",
+  "variable_root_name": "sund",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tsumavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "time: sum within days time: mean over days",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tsumavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tavg-1000hpa-hxy-u.json
+++ b/known_branded_variable/ta_tavg-1000hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tavg-1000hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tavg-1000hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-1000hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p1000"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "1000hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tavg-100hpa-hxy-u.json
+++ b/known_branded_variable/ta_tavg-100hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tavg-100hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tavg-100hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-100hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p100"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "100hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tavg-10hpa-hxy-u.json
+++ b/known_branded_variable/ta_tavg-10hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tavg-10hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tavg-10hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-10hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p10"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "10hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tavg-150hpa-hxy-u.json
+++ b/known_branded_variable/ta_tavg-150hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tavg-150hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tavg-150hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-150hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p150"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "150hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tavg-200hpa-hxy-u.json
+++ b/known_branded_variable/ta_tavg-200hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tavg-200hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tavg-200hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-200hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p200"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "200hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tavg-20hpa-hxy-u.json
+++ b/known_branded_variable/ta_tavg-20hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tavg-20hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tavg-20hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-20hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p20"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "20hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tavg-250hpa-hxy-u.json
+++ b/known_branded_variable/ta_tavg-250hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tavg-250hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tavg-250hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-250hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p250"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "250hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tavg-300hpa-hxy-u.json
+++ b/known_branded_variable/ta_tavg-300hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tavg-300hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tavg-300hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-300hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p300"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "300hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tavg-30hpa-hxy-u.json
+++ b/known_branded_variable/ta_tavg-30hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tavg-30hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tavg-30hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-30hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p30"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "30hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tavg-400hpa-hxy-u.json
+++ b/known_branded_variable/ta_tavg-400hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tavg-400hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tavg-400hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-400hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p400"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "400hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tavg-500hpa-hxy-u.json
+++ b/known_branded_variable/ta_tavg-500hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tavg-500hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "Temperature on the 500 hPa surface",
+  "drs_name": "ta_tavg-500hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-500hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p500"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "500hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tavg-50hpa-hxy-u.json
+++ b/known_branded_variable/ta_tavg-50hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tavg-50hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tavg-50hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-50hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p50"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "50hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tavg-600hpa-hxy-u.json
+++ b/known_branded_variable/ta_tavg-600hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tavg-600hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tavg-600hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-600hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p600"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "600hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tavg-700hpa-hxy-u.json
+++ b/known_branded_variable/ta_tavg-700hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tavg-700hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "Air temperature at 700hPa",
+  "drs_name": "ta_tavg-700hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-700hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p700"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "700hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tavg-70hpa-hxy-u.json
+++ b/known_branded_variable/ta_tavg-70hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tavg-70hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tavg-70hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-70hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p70"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "70hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tavg-750hpa-hxy-u.json
+++ b/known_branded_variable/ta_tavg-750hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tavg-750hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tavg-750hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-750hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p750"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "750hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tavg-850hpa-hxy-u.json
+++ b/known_branded_variable/ta_tavg-850hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tavg-850hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "Air temperature at 850hPa",
+  "drs_name": "ta_tavg-850hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-850hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p850"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "850hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tavg-925hpa-hxy-u.json
+++ b/known_branded_variable/ta_tavg-925hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tavg-925hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tavg-925hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-925hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p925"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "925hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tavg-h50m-hxy-u.json
+++ b/known_branded_variable/ta_tavg-h50m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tavg-h50m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tavg-h50m-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-h50m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "height50m"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "h50m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tpt-1000hpa-hxy-u.json
+++ b/known_branded_variable/ta_tpt-1000hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tpt-1000hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tpt-1000hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-1000hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p1000"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "1000hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tpt-100hpa-hxy-u.json
+++ b/known_branded_variable/ta_tpt-100hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tpt-100hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tpt-100hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-100hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p100"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "100hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tpt-10hpa-hxy-u.json
+++ b/known_branded_variable/ta_tpt-10hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tpt-10hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tpt-10hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-10hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p10"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "10hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tpt-150hpa-hxy-u.json
+++ b/known_branded_variable/ta_tpt-150hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tpt-150hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tpt-150hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-150hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p150"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "150hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tpt-200hpa-hxy-u.json
+++ b/known_branded_variable/ta_tpt-200hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tpt-200hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tpt-200hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-200hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p200"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "200hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tpt-20hpa-hxy-u.json
+++ b/known_branded_variable/ta_tpt-20hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tpt-20hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tpt-20hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-20hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p20"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "20hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tpt-250hpa-hxy-u.json
+++ b/known_branded_variable/ta_tpt-250hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tpt-250hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tpt-250hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-250hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p250"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "250hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tpt-300hpa-hxy-u.json
+++ b/known_branded_variable/ta_tpt-300hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tpt-300hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tpt-300hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-300hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p300"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "300hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tpt-30hpa-hxy-u.json
+++ b/known_branded_variable/ta_tpt-30hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tpt-30hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tpt-30hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-30hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p30"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "30hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tpt-400hpa-hxy-u.json
+++ b/known_branded_variable/ta_tpt-400hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tpt-400hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tpt-400hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-400hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p400"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "400hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tpt-500hpa-hxy-u.json
+++ b/known_branded_variable/ta_tpt-500hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tpt-500hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tpt-500hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-500hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p500"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "500hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tpt-50hpa-hxy-u.json
+++ b/known_branded_variable/ta_tpt-50hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tpt-50hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tpt-50hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-50hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p50"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "50hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tpt-600hpa-hxy-u.json
+++ b/known_branded_variable/ta_tpt-600hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tpt-600hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tpt-600hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-600hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p600"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "600hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tpt-700hpa-hxy-u.json
+++ b/known_branded_variable/ta_tpt-700hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tpt-700hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tpt-700hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-700hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p700"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "700hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tpt-70hpa-hxy-u.json
+++ b/known_branded_variable/ta_tpt-70hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tpt-70hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tpt-70hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-70hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p70"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "70hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tpt-750hpa-hxy-u.json
+++ b/known_branded_variable/ta_tpt-750hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tpt-750hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tpt-750hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-750hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p750"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "750hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tpt-850hpa-hxy-u.json
+++ b/known_branded_variable/ta_tpt-850hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tpt-850hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tpt-850hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-850hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p850"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "850hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tpt-925hpa-hxy-u.json
+++ b/known_branded_variable/ta_tpt-925hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tpt-925hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tpt-925hPa-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-925hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p925"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "925hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ta_tpt-h50m-hxy-u.json
+++ b/known_branded_variable/ta_tpt-h50m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta_tpt-h50m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ta_tpt-h50m-hxy-u",
+  "cf_standard_name": "air_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ta",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-h50m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "height50m"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "h50m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/thkcello_ti-ol-hxy-u.json
+++ b/known_branded_variable/thkcello_ti-ol-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "thkcello_ti-ol-hxy-u",
+  "type": "known_branded_variable",
+  "description": "'Thickness' means the vertical extent of a layer. 'Cell' refers to a model grid-cell.",
+  "drs_name": "thkcello_ti-ol-hxy-u",
+  "cf_standard_name": "cell_thickness",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "thkcello",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "ti-ol-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "olevel"
+  ],
+  "cell_methods": "area: mean",
+  "cell_measures": "area: areacello volume: volcello",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "ti",
+  "vertical_label": "ol",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/tsl_tpt-sl-hxy-lnd.json
+++ b/known_branded_variable/tsl_tpt-sl-hxy-lnd.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tsl_tpt-sl-hxy-lnd",
+  "type": "known_branded_variable",
+  "description": "Temperature of soil. Reported as missing for grid cells with no land.",
+  "drs_name": "tsl_tpt-sl-hxy-lnd",
+  "cf_standard_name": "soil_temperature",
+  "cf_units": "K",
+  "cf_sn_status": "approved",
+  "variable_root_name": "tsl",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-sl-hxy-lnd",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "sdepth",
+    "time1"
+  ],
+  "cell_methods": "area: mean where land time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "sl",
+  "horizontal_label": "hxy",
+  "area_label": "lnd",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tavg-1000hpa-hxy-u.json
+++ b/known_branded_variable/ua_tavg-1000hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tavg-1000hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tavg-1000hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-1000hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p1000"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "1000hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tavg-100hpa-hxy-u.json
+++ b/known_branded_variable/ua_tavg-100hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tavg-100hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tavg-100hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-100hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p100"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "100hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tavg-10hpa-hxy-u.json
+++ b/known_branded_variable/ua_tavg-10hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tavg-10hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "Zonal wind on the 10 hPa surface",
+  "drs_name": "ua_tavg-10hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-10hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p10"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "10hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tavg-150hpa-hxy-u.json
+++ b/known_branded_variable/ua_tavg-150hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tavg-150hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tavg-150hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-150hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p150"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "150hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tavg-200hpa-hxy-u.json
+++ b/known_branded_variable/ua_tavg-200hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tavg-200hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tavg-200hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-200hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p200"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "200hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tavg-20hpa-hxy-u.json
+++ b/known_branded_variable/ua_tavg-20hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tavg-20hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tavg-20hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-20hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p20"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "20hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tavg-250hpa-hxy-u.json
+++ b/known_branded_variable/ua_tavg-250hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tavg-250hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tavg-250hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-250hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p250"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "250hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tavg-300hpa-hxy-u.json
+++ b/known_branded_variable/ua_tavg-300hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tavg-300hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tavg-300hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-300hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p300"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "300hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tavg-30hpa-hxy-u.json
+++ b/known_branded_variable/ua_tavg-30hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tavg-30hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tavg-30hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-30hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p30"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "30hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tavg-400hpa-hxy-u.json
+++ b/known_branded_variable/ua_tavg-400hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tavg-400hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tavg-400hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-400hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p400"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "400hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tavg-500hpa-hxy-u.json
+++ b/known_branded_variable/ua_tavg-500hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tavg-500hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tavg-500hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-500hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p500"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "500hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tavg-50hpa-hxy-u.json
+++ b/known_branded_variable/ua_tavg-50hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tavg-50hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tavg-50hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-50hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p50"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "50hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tavg-600hpa-hxy-u.json
+++ b/known_branded_variable/ua_tavg-600hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tavg-600hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tavg-600hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-600hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p600"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "600hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tavg-700hpa-hxy-u.json
+++ b/known_branded_variable/ua_tavg-700hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tavg-700hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tavg-700hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-700hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p700"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "700hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tavg-70hpa-hxy-u.json
+++ b/known_branded_variable/ua_tavg-70hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tavg-70hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tavg-70hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-70hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p70"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "70hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tavg-750hpa-hxy-u.json
+++ b/known_branded_variable/ua_tavg-750hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tavg-750hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tavg-750hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-750hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p750"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "750hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tavg-850hpa-hxy-u.json
+++ b/known_branded_variable/ua_tavg-850hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tavg-850hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tavg-850hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-850hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p850"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "850hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tavg-925hpa-hxy-u.json
+++ b/known_branded_variable/ua_tavg-925hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tavg-925hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tavg-925hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-925hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p925"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "925hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tavg-h150m-hxy-u.json
+++ b/known_branded_variable/ua_tavg-h150m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tavg-h150m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tavg-h150m-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-h150m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "height150m"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "h150m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tavg-h200m-hxy-u.json
+++ b/known_branded_variable/ua_tavg-h200m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tavg-h200m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tavg-h200m-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-h200m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "height200m"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "h200m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tavg-h250m-hxy-u.json
+++ b/known_branded_variable/ua_tavg-h250m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tavg-h250m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tavg-h250m-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-h250m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "height250m"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "h250m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tavg-h300m-hxy-u.json
+++ b/known_branded_variable/ua_tavg-h300m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tavg-h300m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tavg-h300m-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-h300m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "height300m"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "h300m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tavg-h50m-hxy-u.json
+++ b/known_branded_variable/ua_tavg-h50m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tavg-h50m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tavg-h50m-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-h50m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "height50m"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "h50m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tpt-1000hpa-hxy-u.json
+++ b/known_branded_variable/ua_tpt-1000hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tpt-1000hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tpt-1000hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-1000hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p1000"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "1000hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tpt-100hpa-hxy-u.json
+++ b/known_branded_variable/ua_tpt-100hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tpt-100hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tpt-100hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-100hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p100"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "100hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tpt-10hpa-hxy-u.json
+++ b/known_branded_variable/ua_tpt-10hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tpt-10hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tpt-10hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-10hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p10"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "10hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tpt-150hpa-hxy-u.json
+++ b/known_branded_variable/ua_tpt-150hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tpt-150hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tpt-150hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-150hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p150"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "150hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tpt-20hpa-hxy-u.json
+++ b/known_branded_variable/ua_tpt-20hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tpt-20hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tpt-20hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-20hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p20"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "20hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tpt-250hpa-hxy-u.json
+++ b/known_branded_variable/ua_tpt-250hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tpt-250hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tpt-250hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-250hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p250"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "250hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tpt-300hpa-hxy-u.json
+++ b/known_branded_variable/ua_tpt-300hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tpt-300hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tpt-300hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-300hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p300"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "300hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tpt-30hpa-hxy-u.json
+++ b/known_branded_variable/ua_tpt-30hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tpt-30hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tpt-30hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-30hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p30"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "30hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tpt-400hpa-hxy-u.json
+++ b/known_branded_variable/ua_tpt-400hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tpt-400hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tpt-400hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-400hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p400"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "400hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tpt-500hpa-hxy-u.json
+++ b/known_branded_variable/ua_tpt-500hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tpt-500hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tpt-500hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-500hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p500"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "500hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tpt-50hpa-hxy-u.json
+++ b/known_branded_variable/ua_tpt-50hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tpt-50hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tpt-50hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-50hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p50"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "50hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tpt-600hpa-hxy-u.json
+++ b/known_branded_variable/ua_tpt-600hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tpt-600hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tpt-600hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-600hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p600"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "600hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tpt-700hpa-hxy-u.json
+++ b/known_branded_variable/ua_tpt-700hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tpt-700hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tpt-700hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-700hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p700"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "700hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tpt-70hpa-hxy-u.json
+++ b/known_branded_variable/ua_tpt-70hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tpt-70hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tpt-70hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-70hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p70"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "70hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tpt-750hpa-hxy-u.json
+++ b/known_branded_variable/ua_tpt-750hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tpt-750hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tpt-750hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-750hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p750"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "750hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tpt-850hpa-hxy-u.json
+++ b/known_branded_variable/ua_tpt-850hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tpt-850hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tpt-850hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-850hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p850"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "850hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tpt-925hpa-hxy-u.json
+++ b/known_branded_variable/ua_tpt-925hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tpt-925hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tpt-925hPa-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-925hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p925"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "925hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tpt-h150m-hxy-u.json
+++ b/known_branded_variable/ua_tpt-h150m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tpt-h150m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tpt-h150m-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-h150m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "height150m"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "h150m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tpt-h200m-hxy-u.json
+++ b/known_branded_variable/ua_tpt-h200m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tpt-h200m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tpt-h200m-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-h200m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "height200m"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "h200m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tpt-h250m-hxy-u.json
+++ b/known_branded_variable/ua_tpt-h250m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tpt-h250m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tpt-h250m-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-h250m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "height250m"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "h250m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tpt-h300m-hxy-u.json
+++ b/known_branded_variable/ua_tpt-h300m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tpt-h300m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tpt-h300m-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-h300m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "height300m"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "h300m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/ua_tpt-h50m-hxy-u.json
+++ b/known_branded_variable/ua_tpt-h50m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua_tpt-h50m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "ua_tpt-h50m-hxy-u",
+  "cf_standard_name": "eastward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "ua",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-h50m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "height50m"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "h50m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/uo_tavg-ol-hxy-u.json
+++ b/known_branded_variable/uo_tavg-ol-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "uo_tavg-ol-hxy-u",
+  "type": "known_branded_variable",
+  "description": "Prognostic x-ward velocity component resolved by the model.",
+  "drs_name": "uo_tavg-ol-hxy-u",
+  "cf_standard_name": "sea_water_x_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "uo",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-ol-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "olevel",
+    "time"
+  ],
+  "cell_methods": "time: mean",
+  "cell_measures": "--OPT",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "ol",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tavg-1000hpa-hxy-u.json
+++ b/known_branded_variable/va_tavg-1000hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tavg-1000hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tavg-1000hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-1000hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p1000"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "1000hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tavg-100hpa-hxy-u.json
+++ b/known_branded_variable/va_tavg-100hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tavg-100hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tavg-100hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-100hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p100"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "100hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tavg-10hpa-hxy-u.json
+++ b/known_branded_variable/va_tavg-10hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tavg-10hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tavg-10hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-10hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p10"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "10hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tavg-150hpa-hxy-u.json
+++ b/known_branded_variable/va_tavg-150hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tavg-150hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tavg-150hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-150hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p150"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "150hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tavg-200hpa-hxy-u.json
+++ b/known_branded_variable/va_tavg-200hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tavg-200hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tavg-200hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-200hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p200"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "200hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tavg-20hpa-hxy-u.json
+++ b/known_branded_variable/va_tavg-20hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tavg-20hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tavg-20hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-20hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p20"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "20hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tavg-250hpa-hxy-u.json
+++ b/known_branded_variable/va_tavg-250hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tavg-250hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tavg-250hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-250hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p250"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "250hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tavg-300hpa-hxy-u.json
+++ b/known_branded_variable/va_tavg-300hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tavg-300hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tavg-300hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-300hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p300"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "300hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tavg-30hpa-hxy-u.json
+++ b/known_branded_variable/va_tavg-30hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tavg-30hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tavg-30hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-30hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p30"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "30hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tavg-400hpa-hxy-u.json
+++ b/known_branded_variable/va_tavg-400hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tavg-400hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tavg-400hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-400hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p400"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "400hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tavg-500hpa-hxy-u.json
+++ b/known_branded_variable/va_tavg-500hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tavg-500hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tavg-500hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-500hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p500"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "500hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tavg-50hpa-hxy-u.json
+++ b/known_branded_variable/va_tavg-50hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tavg-50hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tavg-50hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-50hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p50"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "50hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tavg-600hpa-hxy-u.json
+++ b/known_branded_variable/va_tavg-600hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tavg-600hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tavg-600hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-600hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p600"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "600hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tavg-700hpa-hxy-u.json
+++ b/known_branded_variable/va_tavg-700hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tavg-700hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tavg-700hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-700hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p700"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "700hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tavg-70hpa-hxy-u.json
+++ b/known_branded_variable/va_tavg-70hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tavg-70hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tavg-70hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-70hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p70"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "70hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tavg-750hpa-hxy-u.json
+++ b/known_branded_variable/va_tavg-750hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tavg-750hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tavg-750hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-750hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p750"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "750hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tavg-850hpa-hxy-u.json
+++ b/known_branded_variable/va_tavg-850hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tavg-850hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tavg-850hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-850hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p850"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "850hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tavg-925hpa-hxy-u.json
+++ b/known_branded_variable/va_tavg-925hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tavg-925hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tavg-925hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-925hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p925"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "925hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tavg-h150m-hxy-u.json
+++ b/known_branded_variable/va_tavg-h150m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tavg-h150m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tavg-h150m-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-h150m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "height150m"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "h150m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tavg-h200m-hxy-u.json
+++ b/known_branded_variable/va_tavg-h200m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tavg-h200m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tavg-h200m-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-h200m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "height200m"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "h200m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tavg-h250m-hxy-u.json
+++ b/known_branded_variable/va_tavg-h250m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tavg-h250m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tavg-h250m-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-h250m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "height250m"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "h250m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tavg-h300m-hxy-u.json
+++ b/known_branded_variable/va_tavg-h300m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tavg-h300m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tavg-h300m-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-h300m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "height300m"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "h300m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tavg-h50m-hxy-u.json
+++ b/known_branded_variable/va_tavg-h50m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tavg-h50m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tavg-h50m-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-h50m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "height50m"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "h50m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tpt-1000hpa-hxy-u.json
+++ b/known_branded_variable/va_tpt-1000hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tpt-1000hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tpt-1000hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-1000hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p1000"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "1000hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tpt-100hpa-hxy-u.json
+++ b/known_branded_variable/va_tpt-100hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tpt-100hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tpt-100hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-100hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p100"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "100hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tpt-10hpa-hxy-u.json
+++ b/known_branded_variable/va_tpt-10hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tpt-10hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tpt-10hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-10hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p10"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "10hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tpt-150hpa-hxy-u.json
+++ b/known_branded_variable/va_tpt-150hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tpt-150hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tpt-150hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-150hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p150"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "150hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tpt-20hpa-hxy-u.json
+++ b/known_branded_variable/va_tpt-20hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tpt-20hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tpt-20hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-20hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p20"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "20hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tpt-250hpa-hxy-u.json
+++ b/known_branded_variable/va_tpt-250hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tpt-250hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tpt-250hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-250hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p250"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "250hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tpt-300hpa-hxy-u.json
+++ b/known_branded_variable/va_tpt-300hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tpt-300hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tpt-300hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-300hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p300"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "300hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tpt-30hpa-hxy-u.json
+++ b/known_branded_variable/va_tpt-30hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tpt-30hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tpt-30hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-30hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p30"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "30hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tpt-400hpa-hxy-u.json
+++ b/known_branded_variable/va_tpt-400hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tpt-400hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tpt-400hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-400hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p400"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "400hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tpt-500hpa-hxy-u.json
+++ b/known_branded_variable/va_tpt-500hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tpt-500hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tpt-500hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-500hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p500"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "500hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tpt-50hpa-hxy-u.json
+++ b/known_branded_variable/va_tpt-50hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tpt-50hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tpt-50hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-50hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p50"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "50hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tpt-600hpa-hxy-u.json
+++ b/known_branded_variable/va_tpt-600hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tpt-600hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tpt-600hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-600hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p600"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "600hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tpt-700hpa-hxy-u.json
+++ b/known_branded_variable/va_tpt-700hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tpt-700hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tpt-700hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-700hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p700"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "700hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tpt-70hpa-hxy-u.json
+++ b/known_branded_variable/va_tpt-70hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tpt-70hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tpt-70hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-70hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p70"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "70hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tpt-750hpa-hxy-u.json
+++ b/known_branded_variable/va_tpt-750hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tpt-750hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tpt-750hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-750hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p750"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "750hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tpt-850hpa-hxy-u.json
+++ b/known_branded_variable/va_tpt-850hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tpt-850hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tpt-850hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-850hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p850"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "850hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tpt-925hpa-hxy-u.json
+++ b/known_branded_variable/va_tpt-925hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tpt-925hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tpt-925hPa-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-925hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p925"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "925hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tpt-h150m-hxy-u.json
+++ b/known_branded_variable/va_tpt-h150m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tpt-h150m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tpt-h150m-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-h150m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "height150m"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "h150m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tpt-h200m-hxy-u.json
+++ b/known_branded_variable/va_tpt-h200m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tpt-h200m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tpt-h200m-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-h200m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "height200m"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "h200m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tpt-h250m-hxy-u.json
+++ b/known_branded_variable/va_tpt-h250m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tpt-h250m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tpt-h250m-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-h250m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "height250m"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "h250m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tpt-h300m-hxy-u.json
+++ b/known_branded_variable/va_tpt-h300m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tpt-h300m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tpt-h300m-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-h300m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "height300m"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "h300m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/va_tpt-h50m-hxy-u.json
+++ b/known_branded_variable/va_tpt-h50m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va_tpt-h50m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "va_tpt-h50m-hxy-u",
+  "cf_standard_name": "northward_wind",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "va",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-h50m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "height50m"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "h50m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/vo_tavg-ol-hxy-u.json
+++ b/known_branded_variable/vo_tavg-ol-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "vo_tavg-ol-hxy-u",
+  "type": "known_branded_variable",
+  "description": "Prognostic y-ward velocity component resolved by the model.",
+  "drs_name": "vo_tavg-ol-hxy-u",
+  "cf_standard_name": "sea_water_y_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "vo",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-ol-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "olevel",
+    "time"
+  ],
+  "cell_methods": "time: mean",
+  "cell_measures": "--OPT",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "ol",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/volcello_ti-ol-hxy-u.json
+++ b/known_branded_variable/volcello_ti-ol-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "volcello_ti-ol-hxy-u",
+  "type": "known_branded_variable",
+  "description": "grid-cell volume ca. 2000.",
+  "drs_name": "volcello_ti-ol-hxy-u",
+  "cf_standard_name": "ocean_volume",
+  "cf_units": "m3",
+  "cf_sn_status": "approved",
+  "variable_root_name": "volcello",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "ti-ol-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "olevel"
+  ],
+  "cell_methods": "area: sum",
+  "cell_measures": "area: areacello volume: volcello",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "ti",
+  "vertical_label": "ol",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/wa_tavg-1000hpa-hxy-u.json
+++ b/known_branded_variable/wa_tavg-1000hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tavg-1000hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tavg-1000hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-1000hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p1000"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "1000hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tavg-100hpa-hxy-u.json
+++ b/known_branded_variable/wa_tavg-100hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tavg-100hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tavg-100hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-100hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p100"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "100hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tavg-10hpa-hxy-u.json
+++ b/known_branded_variable/wa_tavg-10hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tavg-10hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tavg-10hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-10hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p10"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "10hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tavg-150hpa-hxy-u.json
+++ b/known_branded_variable/wa_tavg-150hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tavg-150hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tavg-150hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-150hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p150"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "150hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tavg-200hpa-hxy-u.json
+++ b/known_branded_variable/wa_tavg-200hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tavg-200hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tavg-200hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-200hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p200"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "200hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tavg-20hpa-hxy-u.json
+++ b/known_branded_variable/wa_tavg-20hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tavg-20hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tavg-20hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-20hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p20"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "20hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tavg-250hpa-hxy-u.json
+++ b/known_branded_variable/wa_tavg-250hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tavg-250hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tavg-250hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-250hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p250"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "250hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tavg-300hpa-hxy-u.json
+++ b/known_branded_variable/wa_tavg-300hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tavg-300hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tavg-300hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-300hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p300"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "300hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tavg-30hpa-hxy-u.json
+++ b/known_branded_variable/wa_tavg-30hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tavg-30hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tavg-30hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-30hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p30"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "30hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tavg-400hpa-hxy-u.json
+++ b/known_branded_variable/wa_tavg-400hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tavg-400hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tavg-400hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-400hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p400"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "400hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tavg-500hpa-hxy-u.json
+++ b/known_branded_variable/wa_tavg-500hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tavg-500hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tavg-500hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-500hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p500"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "500hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tavg-50hpa-hxy-u.json
+++ b/known_branded_variable/wa_tavg-50hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tavg-50hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tavg-50hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-50hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p50"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "50hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tavg-600hpa-hxy-u.json
+++ b/known_branded_variable/wa_tavg-600hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tavg-600hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tavg-600hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-600hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p600"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "600hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tavg-700hpa-hxy-u.json
+++ b/known_branded_variable/wa_tavg-700hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tavg-700hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tavg-700hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-700hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p700"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "700hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tavg-70hpa-hxy-u.json
+++ b/known_branded_variable/wa_tavg-70hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tavg-70hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tavg-70hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-70hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p70"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "70hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tavg-750hpa-hxy-u.json
+++ b/known_branded_variable/wa_tavg-750hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tavg-750hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tavg-750hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-750hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p750"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "750hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tavg-850hpa-hxy-u.json
+++ b/known_branded_variable/wa_tavg-850hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tavg-850hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tavg-850hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-850hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p850"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "850hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tavg-925hpa-hxy-u.json
+++ b/known_branded_variable/wa_tavg-925hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tavg-925hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tavg-925hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-925hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p925"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "925hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tpt-1000hpa-hxy-u.json
+++ b/known_branded_variable/wa_tpt-1000hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tpt-1000hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tpt-1000hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-1000hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p1000"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "1000hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tpt-100hpa-hxy-u.json
+++ b/known_branded_variable/wa_tpt-100hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tpt-100hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tpt-100hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-100hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p100"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "100hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tpt-10hpa-hxy-u.json
+++ b/known_branded_variable/wa_tpt-10hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tpt-10hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tpt-10hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-10hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p10"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "10hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tpt-150hpa-hxy-u.json
+++ b/known_branded_variable/wa_tpt-150hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tpt-150hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tpt-150hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-150hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p150"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "150hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tpt-200hpa-hxy-u.json
+++ b/known_branded_variable/wa_tpt-200hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tpt-200hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tpt-200hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-200hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p200"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "200hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tpt-20hpa-hxy-u.json
+++ b/known_branded_variable/wa_tpt-20hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tpt-20hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tpt-20hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-20hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p20"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "20hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tpt-250hpa-hxy-u.json
+++ b/known_branded_variable/wa_tpt-250hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tpt-250hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tpt-250hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-250hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p250"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "250hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tpt-300hpa-hxy-u.json
+++ b/known_branded_variable/wa_tpt-300hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tpt-300hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tpt-300hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-300hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p300"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "300hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tpt-30hpa-hxy-u.json
+++ b/known_branded_variable/wa_tpt-30hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tpt-30hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tpt-30hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-30hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p30"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "30hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tpt-400hpa-hxy-u.json
+++ b/known_branded_variable/wa_tpt-400hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tpt-400hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tpt-400hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-400hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p400"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "400hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tpt-500hpa-hxy-u.json
+++ b/known_branded_variable/wa_tpt-500hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tpt-500hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tpt-500hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-500hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p500"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "500hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tpt-50hpa-hxy-u.json
+++ b/known_branded_variable/wa_tpt-50hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tpt-50hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tpt-50hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-50hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p50"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "50hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tpt-600hpa-hxy-u.json
+++ b/known_branded_variable/wa_tpt-600hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tpt-600hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tpt-600hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-600hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p600"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "600hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tpt-700hpa-hxy-u.json
+++ b/known_branded_variable/wa_tpt-700hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tpt-700hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tpt-700hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-700hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p700"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "700hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tpt-70hpa-hxy-u.json
+++ b/known_branded_variable/wa_tpt-70hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tpt-70hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tpt-70hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-70hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p70"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "70hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tpt-750hpa-hxy-u.json
+++ b/known_branded_variable/wa_tpt-750hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tpt-750hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tpt-750hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-750hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p750"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "750hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tpt-850hpa-hxy-u.json
+++ b/known_branded_variable/wa_tpt-850hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tpt-850hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tpt-850hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-850hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p850"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "850hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wa_tpt-925hpa-hxy-u.json
+++ b/known_branded_variable/wa_tpt-925hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa_tpt-925hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wa_tpt-925hPa-hxy-u",
+  "cf_standard_name": "upward_air_velocity",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wa",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-925hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p925"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "925hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "up"
+}

--- a/known_branded_variable/wetno3_tavg-u-hxy-u.json
+++ b/known_branded_variable/wetno3_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wetno3_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wetno3_tavg-u-hxy-u",
+  "cf_standard_name": "tendency_of_atmosphere_mass_content_of_nitrate_dry_aerosol_particles_due_to_wet_deposition",
+  "cf_units": "kg m-2 s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wetno3",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": "down"
+}

--- a/known_branded_variable/wfonocorr_tavg-u-hxy-sea.json
+++ b/known_branded_variable/wfonocorr_tavg-u-hxy-sea.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wfonocorr_tavg-u-hxy-sea",
+  "type": "known_branded_variable",
+  "description": "Computed as the water flux (without flux correction) into the ocean divided by the area of the ocean portion of the grid cell.",
+  "drs_name": "wfonocorr_tavg-u-hxy-sea",
+  "cf_standard_name": "water_flux_into_sea_water_without_flux_correction",
+  "cf_units": "kg m-2 s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wfonocorr",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-sea",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: mean where sea time: mean",
+  "cell_measures": "area: areacello",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "sea",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/wsgs_tmax-h10m-hxy-u.json
+++ b/known_branded_variable/wsgs_tmax-h10m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wsgs_tmax-h10m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wsgs_tmax-h10m-hxy-u",
+  "cf_standard_name": "wind_speed_of_gust",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wsgs",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tmax-h10m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "height10m"
+  ],
+  "cell_methods": "area: mean time: maximum",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tmax",
+  "vertical_label": "h10m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/wsgs_tmaxavg-h10m-hxy-u.json
+++ b/known_branded_variable/wsgs_tmaxavg-h10m-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wsgs_tmaxavg-h10m-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "wsgs_tmaxavg-h10m-hxy-u",
+  "cf_standard_name": "wind_speed_of_gust",
+  "cf_units": "m s-1",
+  "cf_sn_status": "approved",
+  "variable_root_name": "wsgs",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tmaxavg-h10m-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "height10m"
+  ],
+  "cell_methods": "area: mean time: maximum within days time: mean over days",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tmaxavg",
+  "vertical_label": "h10m",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/z0_tavg-u-hxy-u.json
+++ b/known_branded_variable/z0_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "z0_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "z0_tavg-u-hxy-u",
+  "cf_standard_name": "surface_roughness_length",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "z0",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tavg-1000hpa-hxy-u.json
+++ b/known_branded_variable/zg_tavg-1000hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tavg-1000hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "Geopotential height on the 1000 hPa surface",
+  "drs_name": "zg_tavg-1000hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-1000hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p1000"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "1000hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tavg-100hpa-hxy-u.json
+++ b/known_branded_variable/zg_tavg-100hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tavg-100hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "Geopotential height on the 100 hPa surface",
+  "drs_name": "zg_tavg-100hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-100hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p100"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "100hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tavg-10hpa-hxy-u.json
+++ b/known_branded_variable/zg_tavg-10hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tavg-10hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "Geopotential height on the 10hPa surface",
+  "drs_name": "zg_tavg-10hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-10hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p10"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "10hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tavg-150hpa-hxy-u.json
+++ b/known_branded_variable/zg_tavg-150hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tavg-150hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tavg-150hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-150hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p150"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "150hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tavg-200hpa-hxy-u.json
+++ b/known_branded_variable/zg_tavg-200hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tavg-200hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tavg-200hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-200hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p200"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "200hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tavg-20hpa-hxy-u.json
+++ b/known_branded_variable/zg_tavg-20hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tavg-20hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tavg-20hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-20hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p20"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "20hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tavg-250hpa-hxy-u.json
+++ b/known_branded_variable/zg_tavg-250hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tavg-250hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tavg-250hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-250hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p250"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "250hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tavg-300hpa-hxy-u.json
+++ b/known_branded_variable/zg_tavg-300hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tavg-300hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tavg-300hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-300hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p300"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "300hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tavg-30hpa-hxy-u.json
+++ b/known_branded_variable/zg_tavg-30hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tavg-30hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tavg-30hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-30hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p30"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "30hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tavg-400hpa-hxy-u.json
+++ b/known_branded_variable/zg_tavg-400hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tavg-400hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tavg-400hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-400hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p400"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "400hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tavg-500hpa-hxy-u.json
+++ b/known_branded_variable/zg_tavg-500hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tavg-500hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "geopotential height on the 500 hPa surface",
+  "drs_name": "zg_tavg-500hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-500hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p500"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "500hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tavg-50hpa-hxy-u.json
+++ b/known_branded_variable/zg_tavg-50hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tavg-50hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tavg-50hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-50hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p50"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "50hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tavg-600hpa-hxy-u.json
+++ b/known_branded_variable/zg_tavg-600hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tavg-600hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tavg-600hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-600hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p600"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "600hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tavg-700hpa-hxy-u.json
+++ b/known_branded_variable/zg_tavg-700hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tavg-700hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tavg-700hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-700hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p700"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "700hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tavg-70hpa-hxy-u.json
+++ b/known_branded_variable/zg_tavg-70hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tavg-70hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tavg-70hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-70hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p70"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "70hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tavg-750hpa-hxy-u.json
+++ b/known_branded_variable/zg_tavg-750hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tavg-750hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tavg-750hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-750hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p750"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "750hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tavg-850hpa-hxy-u.json
+++ b/known_branded_variable/zg_tavg-850hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tavg-850hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tavg-850hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-850hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p850"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "850hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tavg-925hpa-hxy-u.json
+++ b/known_branded_variable/zg_tavg-925hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tavg-925hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tavg-925hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-925hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time",
+    "p925"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "925hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tpt-1000hpa-hxy-u.json
+++ b/known_branded_variable/zg_tpt-1000hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tpt-1000hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "Geopotential height on the 1000 hPa surface",
+  "drs_name": "zg_tpt-1000hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-1000hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p1000"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "1000hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tpt-100hpa-hxy-u.json
+++ b/known_branded_variable/zg_tpt-100hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tpt-100hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tpt-100hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-100hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p100"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "100hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tpt-10hpa-hxy-u.json
+++ b/known_branded_variable/zg_tpt-10hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tpt-10hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tpt-10hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-10hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p10"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "10hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tpt-150hpa-hxy-u.json
+++ b/known_branded_variable/zg_tpt-150hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tpt-150hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tpt-150hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-150hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p150"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "150hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tpt-200hpa-hxy-u.json
+++ b/known_branded_variable/zg_tpt-200hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tpt-200hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tpt-200hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-200hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p200"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "200hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tpt-20hpa-hxy-u.json
+++ b/known_branded_variable/zg_tpt-20hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tpt-20hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tpt-20hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-20hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p20"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "20hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tpt-250hpa-hxy-u.json
+++ b/known_branded_variable/zg_tpt-250hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tpt-250hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tpt-250hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-250hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p250"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "250hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tpt-300hpa-hxy-u.json
+++ b/known_branded_variable/zg_tpt-300hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tpt-300hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tpt-300hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-300hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p300"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "300hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tpt-30hpa-hxy-u.json
+++ b/known_branded_variable/zg_tpt-30hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tpt-30hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tpt-30hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-30hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p30"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "30hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tpt-400hpa-hxy-u.json
+++ b/known_branded_variable/zg_tpt-400hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tpt-400hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tpt-400hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-400hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p400"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "400hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tpt-500hpa-hxy-u.json
+++ b/known_branded_variable/zg_tpt-500hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tpt-500hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "geopotential height on the 500 hPa surface",
+  "drs_name": "zg_tpt-500hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-500hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p500"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "500hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tpt-50hpa-hxy-u.json
+++ b/known_branded_variable/zg_tpt-50hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tpt-50hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tpt-50hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-50hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p50"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "50hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tpt-600hpa-hxy-u.json
+++ b/known_branded_variable/zg_tpt-600hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tpt-600hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tpt-600hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-600hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p600"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "600hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tpt-70hpa-hxy-u.json
+++ b/known_branded_variable/zg_tpt-70hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tpt-70hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tpt-70hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-70hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p70"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "70hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tpt-750hpa-hxy-u.json
+++ b/known_branded_variable/zg_tpt-750hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tpt-750hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tpt-750hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-750hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p750"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "750hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zg_tpt-850hpa-hxy-u.json
+++ b/known_branded_variable/zg_tpt-850hpa-hxy-u.json
@@ -1,0 +1,29 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg_tpt-850hpa-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zg_tpt-850hPa-hxy-u",
+  "cf_standard_name": "geopotential_height",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zg",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-850hPa-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1",
+    "p850"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "850hPa",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zmla_tavg-u-hxy-u.json
+++ b/known_branded_variable/zmla_tavg-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zmla_tavg-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "The atmosphere boundary layer thickness is the 'depth' or 'height' of the (atmosphere) planetary boundary layer.",
+  "drs_name": "zmla_tavg-u-hxy-u",
+  "cf_standard_name": "atmosphere_boundary_layer_thickness",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zmla",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tavg-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time"
+  ],
+  "cell_methods": "area: time: mean",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tavg",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zmla_tpt-u-hxy-u.json
+++ b/known_branded_variable/zmla_tpt-u-hxy-u.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zmla_tpt-u-hxy-u",
+  "type": "known_branded_variable",
+  "description": "",
+  "drs_name": "zmla_tpt-u-hxy-u",
+  "cf_standard_name": "atmosphere_boundary_layer_thickness",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zmla",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-u",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean time: point",
+  "cell_measures": "area: areacella",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "u",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/known_branded_variable/zos_tpt-u-hxy-sea.json
+++ b/known_branded_variable/zos_tpt-u-hxy-sea.json
@@ -1,0 +1,28 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zos_tpt-u-hxy-sea",
+  "type": "known_branded_variable",
+  "description": "This is the dynamic sea level, so should have zero global area mean. It should not include inverse barometer depressions from sea ice.",
+  "drs_name": "zos_tpt-u-hxy-sea",
+  "cf_standard_name": "sea_surface_height_above_geoid",
+  "cf_units": "m",
+  "cf_sn_status": "approved",
+  "variable_root_name": "zos",
+  "var_def_qualifier": "",
+  "branding_suffix_name": "tpt-u-hxy-sea",
+  "dimensions": [
+    "longitude",
+    "latitude",
+    "time1"
+  ],
+  "cell_methods": "area: mean where sea time: point",
+  "cell_measures": "area: areacello",
+  "history": ": registered",
+  "realm": "",
+  "temporal_label": "tpt",
+  "vertical_label": "u",
+  "horizontal_label": "hxy",
+  "area_label": "sea",
+  "bn_status": "accepted",
+  "positive_direction": ""
+}

--- a/temporal_label/tavgmax.json
+++ b/temporal_label/tavgmax.json
@@ -1,0 +1,7 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tavgmax",
+  "type": "temporal_label",
+  "description": "Data is the maximum of the hourly mean over each time period (i.e. each reported interval defined by its time bounds).For example, the data may be reported daily, with each value being the maximum of the hourly mean precipitation rate.",
+  "drs_name": "tavgmax"
+}

--- a/temporal_label/tsumavg.json
+++ b/temporal_label/tsumavg.json
@@ -1,0 +1,7 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tsumavg",
+  "type": "temporal_label",
+  "description": "Data is the mean of daily sum over each time period (i.e. each reported interval defined by its time bounds).For example, the data may be reported monthly, with each value being the mean of the daily sunshine duration for each day in a month.",
+  "drs_name": "tsumavg"
+}

--- a/vertical_label/150hpa.json
+++ b/vertical_label/150hpa.json
@@ -1,0 +1,7 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "150hpa",
+  "type": "vertical_label",
+  "description": "Data is reported at an atmospheric pressure of 150 hPa.",
+  "drs_name": "150hPa"
+}

--- a/vertical_label/20hpa.json
+++ b/vertical_label/20hpa.json
@@ -1,0 +1,7 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "20hpa",
+  "type": "vertical_label",
+  "description": "Data is reported at an atmospheric pressure of 20 hPa.",
+  "drs_name": "20hPa"
+}

--- a/vertical_label/250hpa.json
+++ b/vertical_label/250hpa.json
@@ -1,0 +1,7 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "250hpa",
+  "type": "vertical_label",
+  "description": "Data is reported at an atmospheric pressure of 250 hPa.",
+  "drs_name": "250hPa"
+}

--- a/vertical_label/300hpa.json
+++ b/vertical_label/300hpa.json
@@ -1,0 +1,7 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "300hpa",
+  "type": "vertical_label",
+  "description": "Data is reported at an atmospheric pressure of 300 hPa.",
+  "drs_name": "300hPa"
+}

--- a/vertical_label/30hpa.json
+++ b/vertical_label/30hpa.json
@@ -1,0 +1,7 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "30hpa",
+  "type": "vertical_label",
+  "description": "Data is reported at an atmospheric pressure of 30 hPa.",
+  "drs_name": "30hPa"
+}

--- a/vertical_label/400hpa.json
+++ b/vertical_label/400hpa.json
@@ -1,0 +1,7 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "400hpa",
+  "type": "vertical_label",
+  "description": "Data is reported at an atmospheric pressure of 400 hPa.",
+  "drs_name": "400hPa"
+}

--- a/vertical_label/50hpa.json
+++ b/vertical_label/50hpa.json
@@ -1,0 +1,7 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "50hpa",
+  "type": "vertical_label",
+  "description": "Data is reported at an atmospheric pressure of 50 hPa.",
+  "drs_name": "50hPa"
+}

--- a/vertical_label/600hpa.json
+++ b/vertical_label/600hpa.json
@@ -1,0 +1,7 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "600hpa",
+  "type": "vertical_label",
+  "description": "Data is reported at an atmospheric pressure of 600 hPa.",
+  "drs_name": "600hPa"
+}

--- a/vertical_label/70hpa.json
+++ b/vertical_label/70hpa.json
@@ -1,0 +1,7 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "70hpa",
+  "type": "vertical_label",
+  "description": "Data is reported at an atmospheric pressure of 70 hPa.",
+  "drs_name": "70hPa"
+}

--- a/vertical_label/750hpa.json
+++ b/vertical_label/750hpa.json
@@ -1,0 +1,7 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "750hpa",
+  "type": "vertical_label",
+  "description": "Data is reported at an atmospheric pressure of 750 hPa.",
+  "drs_name": "750hPa"
+}

--- a/vertical_label/h150m.json
+++ b/vertical_label/h150m.json
@@ -1,0 +1,7 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "h150m",
+  "type": "vertical_label",
+  "description": "Data is reported at a vertical height of 150m.",
+  "drs_name": "h150m"
+}

--- a/vertical_label/h200m.json
+++ b/vertical_label/h200m.json
@@ -1,0 +1,7 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "h200m",
+  "type": "vertical_label",
+  "description": "Data is reported at a vertical height of 200m.",
+  "drs_name": "h200m"
+}

--- a/vertical_label/h250m.json
+++ b/vertical_label/h250m.json
@@ -1,0 +1,7 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "h250m",
+  "type": "vertical_label",
+  "description": "Data is reported at a vertical height of 250m.",
+  "drs_name": "h250m"
+}

--- a/vertical_label/h300m.json
+++ b/vertical_label/h300m.json
@@ -1,0 +1,7 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "h300m",
+  "type": "vertical_label",
+  "description": "Data is reported at a vertical height of 300m.",
+  "drs_name": "h300m"
+}

--- a/vertical_label/h50m.json
+++ b/vertical_label/h50m.json
@@ -1,0 +1,7 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "h50m",
+  "type": "vertical_label",
+  "description": "Data is reported at a vertical height of 50m.",
+  "drs_name": "h50m"
+}


### PR DESCRIPTION
Sister PR to https://github.com/WCRP-CORDEX/cordex-cmip6-cv/pull/507

This PR adds `known_branded_variable` entries from CORDEX-CMIP6 if they did not yet exist in the universe.
It does the same for `vertical_label` and `horizontal_label`.
`variable` entries apparently all existed.

```
esgvoc admin build   --project-path ./cordex-cmip6-cv   --universe-path ./WCRP-universe   --project-id cordex-cmip6   --cv-version dev   --universe-version dev   --output kbv_test_intermediate2.db --fail-on-missing-links
esgvoc admin validate --full kbv_test_intermediate2.db
```
passed with
```
  ✓ File exists: kbv_test_intermediate2.db
  ✓ Opens as SQLite
  ✓ _esgvoc_metadata table: 10 entries
  ✓ metadata.project_id: cordex-cmip6
  ✓ metadata.cv_version: dev
  ✓ metadata.build_date: 2026-07-30T13:52:12.498802+00:00
  ✓ metadata.esgvoc_version: 4.2.0
  ✓ ingestion_errors: 0
  ✓ pcollections not empty: 28 rows
  ✓ pterms not empty: 1425 rows
  ✓ FTS index pterms_fts5: 1425 rows
  ✓ FTS index pcollections_fts5: 28 rows
  ✓ Sample join query: freetext
  ✓ API term instantiation: 1425 terms across 28 collections OK
```
