### PR TITLE
Add EMD horizontal grid cell entries to `grid`

### DIFF
--- a/grid/g231.json
+++ b/grid/g231.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g231",
+  "type": "grid",
+  "description": "Horizontal grid cell with a cubed sphere grid type and 110 x 110 km resolution.",
+  "drs_name": "g231",
+  "region": "global"
+}


### PR DESCRIPTION
Automated synchronisation of Essential-Model-Documentation entries.

This pull request adds the `grid` entries derived from the EMD `horizontal_grid_cell` entries on `WCRP-CMIP/Essential-Model-Documentation@src-data`.

Generated by `.github/scripts/sync_emd_entries.py`.