### PR TITLE
Add EMD horizontal grid cell entries to `grid`

### DIFF
--- a/grid/g232.json
+++ b/grid/g232.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g232",
+  "type": "grid",
+  "description": "Horizontal grid cell with a stretched grid type and 1.25 x 1 degree resolution.",
+  "drs_name": "g232",
+  "region": "global"
+}


### PR DESCRIPTION
Automated synchronisation of Essential-Model-Documentation entries.

This pull request adds the `grid` entries derived from the EMD `horizontal_grid_cell` entries on `WCRP-CMIP/Essential-Model-Documentation@src-data`.

Generated by `.github/scripts/sync_emd_entries.py`.