### PR TITLE
Add EMD horizontal grid cell entries to `grid`

### DIFF
--- a/grid/g235.json
+++ b/grid/g235.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g235",
+  "type": "grid",
+  "description": "Horizontal grid cell with a reduced gaussian grid type and 100 x 100 km resolution.",
+  "drs_name": "g235",
+  "region": "global"
+}

--- a/grid/g236.json
+++ b/grid/g236.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g236",
+  "type": "grid",
+  "description": "Horizontal grid cell with a unstructured triangular grid type.",
+  "drs_name": "g236",
+  "region": "global"
+}


### PR DESCRIPTION
Automated synchronisation of Essential-Model-Documentation entries.

This pull request adds the `grid` entries derived from the EMD `horizontal_grid_cell` entries on `WCRP-CMIP/Essential-Model-Documentation@src-data`.

Generated by `.github/scripts/sync_emd_entries.py`.