### PR TITLE
Add EMD horizontal grid cell entries to `grid`

### DIFF
--- a/grid/g237.json
+++ b/grid/g237.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g237",
+  "type": "grid",
+  "description": "Horizontal grid cell with a tripolar grid type and 0.25 x 0.25 degree resolution.",
+  "drs_name": "g237",
+  "region": "global"
+}

--- a/grid/g238.json
+++ b/grid/g238.json
@@ -1,0 +1,8 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "g238",
+  "type": "grid",
+  "description": "Horizontal grid cell with a unstructured triangular grid type.",
+  "drs_name": "g238",
+  "region": "global"
+}


### PR DESCRIPTION
Automated synchronisation of Essential-Model-Documentation entries.

This pull request adds the `grid` entries derived from the EMD `horizontal_grid_cell` entries on `WCRP-CMIP/Essential-Model-Documentation@src-data`.

Generated by `.github/scripts/sync_emd_entries.py`.